### PR TITLE
updated possibility to ingest notifications using approvals flow

### DIFF
--- a/docs/CAPABILITY_DATA_SETUP.md
+++ b/docs/CAPABILITY_DATA_SETUP.md
@@ -5,7 +5,7 @@
 - Limits (see description below)
 - Contacts with multiple accounts per user
 - Payments per user
-- Notifications on global target group
+- Notifications on global target group (see description below)
 - Messages per user
 - Actions per user for SEPA CT and/or US Wire arrangements
 - Bill Pay enrolment per user
@@ -69,3 +69,20 @@ Periodic limit per service agreement, for function group "Admin":
 - Transactional limit with amount of 1,000,000
 - Privileges "create" and "approve"
 - Functions SEPA CT, US Domestic Wire and US Foreign Wire
+
+## Notifications setup
+Global notifications are only created be the bank manager using approvals
+In this setup Zero approval policy is configured.
+
+To properly setup notifications: 
+- ```ingest.access.control=true```
+- ```ingest.approvals.for.notifications=true``` (unless approvals flow for notifications is disabled)
+- ```ingest.notifications=true```
+
+It is also possible to disable approvals flow on notifications-presentation-service:
+```
+backbase:
+  notifications:
+    approval:
+      enabled: false
+```

--- a/docs/CAPABILITY_DATA_SETUP.md
+++ b/docs/CAPABILITY_DATA_SETUP.md
@@ -71,7 +71,7 @@ Periodic limit per service agreement, for function group "Admin":
 - Functions SEPA CT, US Domestic Wire and US Foreign Wire
 
 ## Notifications setup
-Global notifications are only created be the bank manager using approvals
+Global notifications are only created by the bank manager using approvals
 In this setup Zero approval policy is configured.
 
 To properly setup notifications: 

--- a/jenkins/bb-fuel.groovy
+++ b/jenkins/bb-fuel.groovy
@@ -53,7 +53,7 @@ pipeline {
                                     "-Duse.pfm.categories.for.transactions=${params.USE_PFM_CATEGORIES_FOR_TRANSACTIONS} " +
                                     "-Dingest.approvals.for.payments=${params.INGEST_APPROVALS_FOR_PAYMENTS} " +
                                     "-Dingest.approvals.for.contacts=${params.INGEST_APPROVALS_FOR_CONTACTS} " +
-                                    "-Dingest.approvals.for.contacts=${params.INGEST_APPROVALS_FOR_NOTIFICATIONS} " +
+                                    "-Dingest.approvals.for.notifications=${params.INGEST_APPROVALS_FOR_NOTIFICATIONS} " +
                                     "-Dingest.limits=${params.INGEST_LIMITS} " +
                                     "-Dingest.contacts=${params.INGEST_CONTACTS} " +
                                     "-Dingest.notifications=${params.INGEST_NOTIFICATIONS} " +

--- a/jenkins/bb-fuel.groovy
+++ b/jenkins/bb-fuel.groovy
@@ -15,6 +15,7 @@ pipeline {
         booleanParam(name: 'USE_PFM_CATEGORIES_FOR_TRANSACTIONS', defaultValue: false, description: 'Use PFM categories for transactions (only applicable when INGEST_TRANSACTIONS = true)')
         booleanParam(name: 'INGEST_APPROVALS_FOR_PAYMENTS', defaultValue: false, description: 'Ingest approvals for payments')
         booleanParam(name: 'INGEST_APPROVALS_FOR_CONTACTS', defaultValue: false, description: 'Ingest approvals for contacts')
+        booleanParam(name: 'INGEST_APPROVALS_FOR_NOTIFICATIONS', defaultValue: false, description: 'Ingest approvals for notifications')
         booleanParam(name: 'INGEST_LIMITS', defaultValue: false, description: 'Ingest limits')
         booleanParam(name: 'INGEST_CONTACTS', defaultValue: false, description: 'Ingest contacts per user')
         booleanParam(name: 'INGEST_NOTIFICATIONS', defaultValue: false, description: 'Ingest notifications on global target group')
@@ -52,6 +53,7 @@ pipeline {
                                     "-Duse.pfm.categories.for.transactions=${params.USE_PFM_CATEGORIES_FOR_TRANSACTIONS} " +
                                     "-Dingest.approvals.for.payments=${params.INGEST_APPROVALS_FOR_PAYMENTS} " +
                                     "-Dingest.approvals.for.contacts=${params.INGEST_APPROVALS_FOR_CONTACTS} " +
+                                    "-Dingest.approvals.for.contacts=${params.INGEST_APPROVALS_FOR_NOTIFICATIONS} " +
                                     "-Dingest.limits=${params.INGEST_LIMITS} " +
                                     "-Dingest.contacts=${params.INGEST_CONTACTS} " +
                                     "-Dingest.notifications=${params.INGEST_NOTIFICATIONS} " +

--- a/src/main/java/com/backbase/ct/bbfuel/client/notification/NotificationsPresentationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/notification/NotificationsPresentationRestClient.java
@@ -1,16 +1,12 @@
 package com.backbase.ct.bbfuel.client.notification;
 
-import static org.apache.http.HttpHeaders.AUTHORIZATION;
-
 import com.backbase.ct.bbfuel.client.common.RestClient;
-import com.backbase.ct.bbfuel.client.tokenconverter.InternalTokenRestClient;
 import com.backbase.ct.bbfuel.config.BbFuelConfiguration;
 import com.backbase.dbs.presentation.notifications.rest.spec.v2.notifications.NotificationsPostRequestBody;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,25 +15,23 @@ public class NotificationsPresentationRestClient extends RestClient {
 
     private final BbFuelConfiguration config;
 
-    @Autowired
-    private InternalTokenRestClient internalTokenRestClient;
-
-    private static final String SERVICE_API = "service-api/";
     private static final String SERVICE_VERSION = "v2";
-    private static final String INTERNAL_TOKEN = "Bearer %s";
-    private static final String ENDPOINT_NOTIFICATIONS = "/notifications";
+    private static final String PATH_EMPLOYEE = "/employee";
+    private static final String ENDPOINT_NOTIFICATIONS = PATH_EMPLOYEE + "/notifications";
+    private static final String NOTIFICATIONS_PRESENTATION_SERVICE = "notifications-presentation-service";
 
+    /** Create notifications base path. */
     @PostConstruct
     public void init() {
-        setBaseUri(config.getDbs().getNotifications());
-        setVersion(SERVICE_API + SERVICE_VERSION);
+        setBaseUri(config.getPlatform().getGateway());
+        setVersion(SERVICE_VERSION);
+        setInitialPath(NOTIFICATIONS_PRESENTATION_SERVICE);
     }
 
+    /** Create notification. */
     public Response createNotification(NotificationsPostRequestBody body) {
         return requestSpec()
             .contentType(ContentType.JSON)
-            .header(AUTHORIZATION, String.format(INTERNAL_TOKEN,
-                internalTokenRestClient.getAuthorisationHeaderForInternalRequest()))
             .body(body)
             .post(getPath(ENDPOINT_NOTIFICATIONS));
     }

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/ApprovalsConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/ApprovalsConfigurator.java
@@ -6,8 +6,11 @@ import static com.backbase.ct.bbfuel.data.ApprovalsDataGenerator.createPolicyAss
 import static com.backbase.ct.bbfuel.data.ApprovalsDataGenerator.createPolicyItemDto;
 import static com.backbase.ct.bbfuel.data.CommonConstants.CONTACTS_FUNCTION_NAME;
 import static com.backbase.ct.bbfuel.data.CommonConstants.CONTACTS_RESOURCE_NAME;
+import static com.backbase.ct.bbfuel.data.CommonConstants.NOTIFICATIONS_FUNCTION_NAME;
+import static com.backbase.ct.bbfuel.data.CommonConstants.NOTIFICATIONS_RESOURCE_NAME;
 import static com.backbase.ct.bbfuel.data.CommonConstants.PAYMENTS_RESOURCE_NAME;
 import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_INGEST_APPROVALS_FOR_CONTACTS;
+import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_INGEST_APPROVALS_FOR_NOTIFICATIONS;
 import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_INGEST_APPROVALS_FOR_PAYMENTS;
 import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_ROOT_ENTITLEMENTS_ADMIN;
 import static com.backbase.ct.bbfuel.data.CommonConstants.SEPA_CT_FUNCTION_NAME;
@@ -77,8 +80,10 @@ public class ApprovalsConfigurator {
         userContextPresentationRestClient.selectContextBasedOnMasterServiceAgreement();
         boolean isPaymentsApprovalsEnabled = globalProperties.getBoolean(PROPERTY_INGEST_APPROVALS_FOR_PAYMENTS);
         boolean isContactsApprovalsEnabled = globalProperties.getBoolean(PROPERTY_INGEST_APPROVALS_FOR_CONTACTS);
+        boolean isNotificationsApprovalsEnabled = globalProperties
+            .getBoolean(PROPERTY_INGEST_APPROVALS_FOR_NOTIFICATIONS);
 
-        if (isPaymentsApprovalsEnabled || isContactsApprovalsEnabled) {
+        if (isPaymentsApprovalsEnabled || isContactsApprovalsEnabled || isNotificationsApprovalsEnabled) {
             setupAccessControlAndAssignApprovalTypes(externalServiceAgreementId);
         }
         if (isPaymentsApprovalsEnabled) {
@@ -86,6 +91,9 @@ public class ApprovalsConfigurator {
         }
         if (isContactsApprovalsEnabled) {
             assignContactsPolicies(externalServiceAgreementId);
+        }
+        if (isNotificationsApprovalsEnabled) {
+            assignNotificationsPolicies(externalServiceAgreementId);
         }
     }
 
@@ -155,6 +163,15 @@ public class ApprovalsConfigurator {
         LOGGER.info("Policies assigned: {}", listOfAssignments);
     }
 
+    private void assignNotificationsPolicies(String externalServiceAgreementId) {
+        List<IntegrationPolicyAssignmentRequest> listOfAssignments =
+            getNotificationsPolicyAssignmentsBasedOnZeroApprovalPolicyOnly(externalServiceAgreementId);
+
+        approvalIntegrationRestClient.assignPolicies(listOfAssignments);
+
+        LOGGER.info("Policies assigned: {}", listOfAssignments);
+    }
+
     private List<IntegrationPolicyAssignmentRequest> getPaymentsPolicyAssignments(
         String externalServiceAgreementId,
         String paymentsFunction) {
@@ -207,6 +224,15 @@ public class ApprovalsConfigurator {
             CONTACTS_RESOURCE_NAME,
             CONTACTS_FUNCTION_NAME,
             singletonList(createPolicyAssignmentRequestBounds(policyAId, null))));
+    }
+
+    private List<IntegrationPolicyAssignmentRequest> getNotificationsPolicyAssignmentsBasedOnZeroApprovalPolicyOnly(
+        String externalServiceAgreementId) {
+        return singletonList(createPolicyAssignmentRequest(
+            externalServiceAgreementId,
+            NOTIFICATIONS_RESOURCE_NAME,
+            NOTIFICATIONS_FUNCTION_NAME,
+            singletonList(createPolicyAssignmentRequestBounds(policyZeroId, null))));
     }
 
     /**

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/NotificationsConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/NotificationsConfigurator.java
@@ -2,6 +2,8 @@ package com.backbase.ct.bbfuel.configurator;
 
 import static org.apache.http.HttpStatus.SC_CREATED;
 
+import com.backbase.ct.bbfuel.client.accessgroup.UserContextPresentationRestClient;
+import com.backbase.ct.bbfuel.client.common.LoginRestClient;
 import com.backbase.ct.bbfuel.client.notification.NotificationsPresentationRestClient;
 import com.backbase.ct.bbfuel.data.CommonConstants;
 import com.backbase.ct.bbfuel.data.NotificationsDataGenerator;
@@ -22,8 +24,18 @@ public class NotificationsConfigurator {
     private static GlobalProperties globalProperties = GlobalProperties.getInstance();
 
     private final NotificationsPresentationRestClient notificationsPresentationRestClient;
+    private final LoginRestClient loginRestClient;
+    private final UserContextPresentationRestClient userContextPresentationRestClient;
 
-    public void ingestNotifications() {
+    /**
+     * Create global notifications. Requires also either ingest.approvals.for.notifications=true or disabled approval
+     * flow on notifications service.
+     *
+     * @param externalUserId - external user ID of notifications manager with create and approve permissions
+     */
+    public void ingestNotifications(String externalUserId) {
+        loginRestClient.login(externalUserId, externalUserId);
+        userContextPresentationRestClient.selectContextBasedOnMasterServiceAgreement();
         int randomAmount = CommonHelpers
             .generateRandomNumberInRange(globalProperties.getInt(CommonConstants.PROPERTY_NOTIFICATIONS_MIN),
                 globalProperties.getInt(CommonConstants.PROPERTY_NOTIFICATIONS_MAX));

--- a/src/main/java/com/backbase/ct/bbfuel/data/CommonConstants.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/CommonConstants.java
@@ -26,7 +26,9 @@ public final class CommonConstants {
     public static final String US_FOREIGN_WIRE_FUNCTION_NAME = "US Foreign Wire";
     public static final String PAYMENTS_RESOURCE_NAME = "Payments";
     public static final String CONTACTS_RESOURCE_NAME = "Contacts";
+    public static final String NOTIFICATIONS_RESOURCE_NAME = "Notifications";
     public static final String CONTACTS_FUNCTION_NAME = CONTACTS_RESOURCE_NAME;
+    public static final String NOTIFICATIONS_FUNCTION_NAME = "Manage Notifications";
     public static final String PRIVILEGE_CREATE = "create";
     public static final String PROPERTY_INGEST_ACCESS_CONTROL = "ingest.access.control";
     public static final String PROPERTY_INGEST_CUSTOM_SERVICE_AGREEMENTS = "ingest.custom.service.agreements";
@@ -46,6 +48,7 @@ public final class CommonConstants {
     public static final String PROPERTY_INGEST_NOTIFICATIONS = "ingest.notifications";
     public static final String PROPERTY_INGEST_APPROVALS_FOR_PAYMENTS = "ingest.approvals.for.payments";
     public static final String PROPERTY_INGEST_APPROVALS_FOR_CONTACTS = "ingest.approvals.for.contacts";
+    public static final String PROPERTY_INGEST_APPROVALS_FOR_NOTIFICATIONS = "ingest.approvals.for.notifications";
     public static final String PROPERTY_INGEST_LIMITS = "ingest.limits";
     public static final String PROPERTY_CONTACTS_MIN = "contacts.min";
     public static final String PROPERTY_CONTACTS_MAX = "contacts.max";

--- a/src/main/resources/data.properties
+++ b/src/main/resources/data.properties
@@ -22,6 +22,7 @@ transactions.max=30
 # Ingest approvals
 ingest.approvals.for.payments=false
 ingest.approvals.for.contacts=false
+ingest.approvals.for.notifications=false
 # Ingest limits
 ingest.limits=false
 # Number of notifications

--- a/src/main/resources/data/job-profiles.json
+++ b/src/main/resources/data/job-profiles.json
@@ -526,7 +526,8 @@
         "privileges": [
           "view",
           "create",
-          "delete"
+          "delete",
+          "approve"
         ]
       },
       {


### PR DESCRIPTION
Updated possibility to ingest notifications using approvals flow that was implemented in 2.16.0, since service layer was restricted to create global notifications