### PR TITLE
fix for failing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - oraclejdk8
 install: true
 
 script:


### PR DESCRIPTION
``` [INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Exception in thread "main" java.lang.reflect.InvocationTargetException
[INFO] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[INFO] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[INFO] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[INFO] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[INFO] 	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
[INFO] 	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
[INFO] Caused by: java.lang.RuntimeException: Class java/util/UUID could not be instrumented.
[INFO] 	at org.jacoco.agent.rt.internal_14f7ee5.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:139)
[INFO] 	at org.jacoco.agent.rt.internal_14f7ee5.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:100)
[INFO] 	at org.jacoco.agent.rt.internal_14f7ee5.PreMain.createRuntime(PreMain.java:55)
[INFO] 	at org.jacoco.agent.rt.internal_14f7ee5.PreMain.premain(PreMain.java:47)
[INFO] 	... 6 more
[INFO] Caused by: java.lang.NoSuchFieldException: $jacocoAccess
[INFO] 	at java.base/java.lang.Class.getField(Class.java:2000)
[INFO] 	at org.jacoco.agent.rt.internal_14f7ee5.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:137)
[INFO] 	... 9 more
[INFO] FATAL ERROR in native method: processing of -javaagent failed
[INFO] Aborted (core dumped)
```