### PR TITLE
CB-3942: upgrade to ssdk 8.3.0 and dbs 2.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ bb-fuel supports multiple DBS versions. See below which version maps to the requ
 
 | DBS version | bb-fuel minimal [version](https://github.com/backbase/bb-fuel/releases) |
 |-------------|-------------------------------------------------------------------------|
-| 2.16.1      | 2.3.13+                                                                 |
+| 2.16.2      | 2.3.19                                                                  |
+| 2.16.1      | 2.3.18                                                                  |
 | 2.16.0      | 2.3.12                                                                  |
 | 2.15.1      | 2.3.1                                                                   |
 | 2.15.0      | 2.3.0+                                                                  |

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>backbase-integration-starter-parent</artifactId>
         <groupId>com.backbase.buildingblocks</groupId>
-        <version>8.2.4</version>
+        <version>8.3.0</version>
     </parent>
 
     <groupId>com.backbase.ct</groupId>
     <artifactId>bb-fuel</artifactId>
-    <version>2.3.18-SNAPSHOT</version>
+    <version>2.3.19-SNAPSHOT</version>
     <name>Backbase :: Capability Testing :: bb-fuel</name>
 
     <scm>
@@ -23,7 +23,9 @@
         <mainClass>com.backbase.ct.bbfuel.BbFuelApplication</mainClass>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <rest-assured.version>3.0.7</rest-assured.version>
+        <rest-assured.version>3.1.0</rest-assured.version>
+        <groovy.version>2.5.6</groovy.version>
+        <guava.version>24.0-jre</guava.version>
         <jackson-databind.version>2.8.11</jackson-databind.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <javafaker.version>0.18</javafaker.version>
@@ -38,7 +40,7 @@
             <dependency>
                 <groupId>com.backbase.dbs</groupId>
                 <artifactId>banking-services-bom</artifactId>
-                <version>2.16.1</version>
+                <version>2.16.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -90,9 +92,19 @@
             <artifactId>contact-integration-external-inbound-spec</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-xml</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>24.0-jre</version>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.iban4j</groupId>


### PR DESCRIPTION
upgrade to ssdk 8.3.0 and dbs 2.16.2
bump rest assured version
fix groovy dependency from ssdk comms