### PR TITLE
Product Seed Changes

### DIFF
--- a/src/main/resources/data/product-group-seed-retail.json
+++ b/src/main/resources/data/product-group-seed-retail.json
@@ -1,0 +1,46 @@
+[
+  {
+    "productGroupName": "General EUR/USD",
+    "currencies": [
+      "EUR",
+      "USD"
+    ],
+    "currentAccountNames": [
+      "Current Account"
+    ],
+    "productIds": [
+      "1", "2", "3", "5", "6", "7"
+    ],
+    "numberOfArrangements": {
+      "min": 5,
+      "max": 8
+    },
+    "numberOfDebitCards": {
+      "min": 2,
+      "max": 3
+    }
+  },
+  {
+    "productGroupName": "Retail Accounts U.S",
+    "isRetail": true,
+    "currencies": [
+      "USD"
+    ],
+    "currentAccountNames": [
+      "Current Account",
+      "Joint Account",
+      "Savings Account"
+    ],
+    "productIds": [
+      "1","2", "4"
+    ],
+    "numberOfArrangements": {
+      "min": 3,
+      "max": 4
+    },
+    "numberOfDebitCards": {
+      "min": 0,
+      "max": 0
+    }
+  }
+]

--- a/src/main/resources/data/product-group-seed.json
+++ b/src/main/resources/data/product-group-seed.json
@@ -199,6 +199,7 @@
   },
   {
     "productGroupName": "General EUR/USD",
+    "isRetail": true,
     "currencies": [
       "EUR",
       "USD"
@@ -216,28 +217,6 @@
     "numberOfDebitCards": {
       "min": 2,
       "max": 3
-    }
-  },
-  {
-    "productGroupName": "Retail Accounts U.S",
-    "isRetail": true,
-    "currencies": [
-      "USD"
-    ],
-    "currentAccountNames": [
-      "Current Account",
-      "Savings Account"
-    ],
-    "productIds": [
-      "1","2", "4"
-    ],
-    "numberOfArrangements": {
-      "min": 3,
-      "max": 4
-    },
-    "numberOfDebitCards": {
-      "min": 0,
-      "max": 0
     }
   }
 ]


### PR DESCRIPTION
- Spawning a product-group-seed for retail to avoid conflicts with the default one;
- Removing 'Retail Accounts U.S' product group from the default product-group-seed;

<img width="832" alt="Screen Shot 2019-09-12 at 14 21 59" src="https://user-images.githubusercontent.com/47349985/64783864-17daac00-d569-11e9-8f3b-774e2d184b0f.png">
![Screen Shot 2019-09-12 at 14 22 09](https://user-images.githubusercontent.com/47349985/64783919-4062a600-d569-11e9-8b94-ad65f63c76f0.png)

