### PR TITLE
Feature/cb 4131 identity

### DIFF
--- a/jenkins/bb-fuel-minimal.groovy
+++ b/jenkins/bb-fuel-minimal.groovy
@@ -27,6 +27,9 @@ pipeline {
                 'Only enable when strictly necessary (long running job)')
         choice(name: 'PERFORMANCE_TEST_DATA', choices: 'retail\nbusiness', description: 'Retail or business performance test data setup')
         choice(name: 'INFRA_BASE_URI', choices: 'infra.backbase.test:8080\neditorial.backbase.test:8080', description: '')
+        booleanParam(name: 'IDENTITY_FEATURE_TOGGLE', defaultValue: false, description: 'Use identity')
+        string(name: 'IDENTITY_REALM', defaultValue: 'backbase', description: 'Identity realm')
+        string(name: 'IDENTITY_CLIENT', defaultValue: 'hybrid-flow', description: 'Identity client')
         string(name: 'BB_FUEL_VERSION', defaultValue: 'latest', description: '')
         booleanParam(name: 'PRERELEASE', defaultValue: false, description: 'Only applicable if BB_FUEL_VERSION = latest')
         string(name: 'ADDITIONAL_ARGUMENTS', defaultValue: '-Dtransactions.min=0 -Dtransactions.max=0 -Djob.profiles.json=data/minimal-bank/job-profiles.json -Dproducts.json=data/minimal-bank/products.json -Dproduct.group.seed.json=data/minimal-bank/product-group-seed.json -Dlegal.entities.with.users.json=data/minimal-bank/legal-entities-with-users.json', description: 'Additional command line arguments for BB-FUEL Minimal')
@@ -62,6 +65,9 @@ pipeline {
                                     "-Dingest.payments=${params.INGEST_PAYMENTS} " +
                                     "-Dingest.messages=${params.INGEST_MESSAGES} " +
                                     "-Dingest.actions=${params.INGEST_ACTIONS} " +
+                                    "-Didentity.feature.toggle=${params.IDENTITY_FEATURE_TOGGLE} " +
+                                    "-Didentity.realm=${params.IDENTITY_REALM} " +
+                                    "-Didentity.client=${params.IDENTITY_CLIENT} " +
                                     customLegalEntitiesWithUsersJson +
                                     "${params.ADDITIONAL_ARGUMENTS}"
                     )

--- a/jenkins/bb-fuel.groovy
+++ b/jenkins/bb-fuel.groovy
@@ -28,6 +28,9 @@ pipeline {
                 'Only enable when strictly necessary (long running job)')
         choice(name: 'PERFORMANCE_TEST_DATA', choices: 'retail\nbusiness', description: 'Retail or business performance test data setup')
         choice(name: 'INFRA_BASE_URI', choices: 'infra.backbase.test:8080\neditorial.backbase.test:8080\nbackbase.test', description: '')
+        booleanParam(name: 'IDENTITY_FEATURE_TOGGLE', defaultValue: false, description: 'Use identity')
+        string(name: 'IDENTITY_REALM', defaultValue: 'backbase', description: 'Identity realm')
+        string(name: 'IDENTITY_CLIENT', defaultValue: 'hybrid-flow', description: 'Identity client')
         string(name: 'BB_FUEL_VERSION', defaultValue: 'latest', description: '')
         booleanParam(name: 'PRERELEASE', defaultValue: false, description: 'Only applicable if BB_FUEL_VERSION = latest')
         string(name: 'ADDITIONAL_ARGUMENTS', defaultValue: '', description: 'Additional command line arguments')
@@ -64,6 +67,9 @@ pipeline {
                                     "-Dingest.messages=${params.INGEST_MESSAGES} " +
                                     "-Dingest.actions=${params.INGEST_ACTIONS} " +
                                     "-Dingest.billpay=${params.INGEST_BILLPAY} " +
+                                    "-Didentity.feature.toggle=${params.IDENTITY_FEATURE_TOGGLE} " +
+                                    "-Didentity.realm=${params.IDENTITY_REALM} " +
+                                    "-Didentity.client=${params.IDENTITY_CLIENT} " +
                                     customLegalEntitiesWithUsersJson +
                                     "${params.ADDITIONAL_ARGUMENTS}"
                     )

--- a/src/main/java/com/backbase/ct/bbfuel/client/common/LoginRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/common/LoginRestClient.java
@@ -1,12 +1,11 @@
 package com.backbase.ct.bbfuel.client.common;
 
 import static com.backbase.ct.bbfuel.data.CommonConstants.ACCESS_TOKEN;
-import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_IDENTITY_BASE_URI;
+import static com.backbase.ct.bbfuel.data.CommonConstants.IDENTITY_AUTH;
+import static com.backbase.ct.bbfuel.data.CommonConstants.IDENTITY_TOKEN_PATH;
 import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_IDENTITY_CLIENT;
 import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_IDENTITY_FEATURE_TOGGLE;
 import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_IDENTITY_REALM;
-import static com.backbase.ct.bbfuel.data.CommonConstants.IDENTITY_AUTH;
-import static com.backbase.ct.bbfuel.data.CommonConstants.IDENTITY_TOKEN_PATH;
 import static org.apache.http.HttpStatus.SC_OK;
 
 import com.backbase.ct.bbfuel.config.BbFuelConfiguration;
@@ -27,10 +26,10 @@ public class LoginRestClient extends RestClient {
 
     @PostConstruct
     public void init() {
-        if (!this.globalProperties.getBoolean(PROPERTY_IDENTITY_FEATURE_TOGGLE)) {
-            setBaseUri(config.getPlatform().getAuth());
+        if (this.globalProperties.getBoolean(PROPERTY_IDENTITY_FEATURE_TOGGLE)) {
+            setBaseUri(config.getPlatform().getIdentity());
         } else {
-            setBaseUri(this.globalProperties.getString(PROPERTY_IDENTITY_BASE_URI));
+            setBaseUri(config.getPlatform().getAuth());
         }
     }
 

--- a/src/main/java/com/backbase/ct/bbfuel/config/PlatformConfig.java
+++ b/src/main/java/com/backbase/ct/bbfuel/config/PlatformConfig.java
@@ -30,4 +30,9 @@ public class PlatformConfig {
      */
     private String tokenconverter;
 
+    /**
+     * URI to identity.
+     */
+    private String identity;
+
 }

--- a/src/main/java/com/backbase/ct/bbfuel/data/CommonConstants.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/CommonConstants.java
@@ -86,7 +86,6 @@ public final class CommonConstants {
 
     // Identity
     public static final String PROPERTY_IDENTITY_FEATURE_TOGGLE = "identity.feature.toggle";
-    public static final String PROPERTY_IDENTITY_BASE_URI = "identity.base.uri";
     public static final String PROPERTY_IDENTITY_REALM = "identity.realm";
     public static final String PROPERTY_IDENTITY_CLIENT = "identity.client";
     public static final String IDENTITY_AUTH = "/auth/realms";

--- a/src/main/java/com/backbase/ct/bbfuel/data/CommonConstants.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/CommonConstants.java
@@ -83,4 +83,13 @@ public final class CommonConstants {
 
     // Transactions
     public static final String PROPERTY_TRANSACTIONS_DATA_JSON = "transactions.data.json";
+
+    // Identity
+    public static final String PROPERTY_IDENTITY_FEATURE_TOGGLE = "identity.feature.toggle";
+    public static final String PROPERTY_IDENTITY_BASE_URI = "identity.base.uri";
+    public static final String PROPERTY_IDENTITY_REALM = "identity.realm";
+    public static final String PROPERTY_IDENTITY_CLIENT = "identity.client";
+    public static final String IDENTITY_AUTH = "/auth/realms";
+    public static final String IDENTITY_TOKEN_PATH = "/protocol/openid-connect/token";
+    public static final String ACCESS_TOKEN = "access_token";
 }

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -4,6 +4,7 @@ environment:
 bb-fuel:
   platform:
     registry: http://registry.${environment.name}.${environment.domain}
+    identity: http://bbiam.${environment.name}.${environment.domain}
     gateway: http://edge.${environment.name}.${environment.domain}/api
     auth: http://edge.${environment.name}.${environment.domain}/auth/login
     tokenconverter: http://tokenconverter.${environment.name}.${environment.domain}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,7 @@
 bb-fuel:
   platform:
     infra: http://localhost:8080
+    identity: http://localhost:8180
     registry: ${bb-fuel.platform.infra}/registry/eureka
     gateway: ${bb-fuel.platform.infra}/gateway/api
     auth: ${bb-fuel.platform.gateway}/auth/login

--- a/src/main/resources/application-pcf.yml
+++ b/src/main/resources/application-pcf.yml
@@ -10,6 +10,7 @@ pcf:
 bb-fuel:
   platform:
     registry: http://registry-${pcf.uri}/eureka
+    identity: http://bbiam-${pcf.uri}
     gateway: http://gateway-${pcf.uri}/api
     auth: ${bb-fuel.platform.gateway}/auth/login
     tokenconverter: http://token-converter-service-${pcf.uri}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,10 +21,12 @@ eureka.client.enabled: false
 
 environment:
   domain: backbase.test:8080
+  domain-identity: backbase.test:8180
 
 bb-fuel:
   platform:
     infra: http://${environment.name}-${infra.base:infra}.${environment.domain}
+    identity: http://${environment.name}-bbiam.${environment.domain-identity}
     registry: ${bb-fuel.platform.infra}/registry/eureka
     gateway: ${bb-fuel.platform.infra}/gateway/api
     auth: ${bb-fuel.platform.gateway}/auth/login

--- a/src/main/resources/data.properties
+++ b/src/main/resources/data.properties
@@ -59,3 +59,8 @@ multi.tenancy.environment=false
 multi.tenancy.legal.entities.with.users.json=data/multitenancy/tenant_a.json;data/multitenancy/tenant_b.json;data/multitenancy/tenant_c.json;data/multitenancy/tenant_d.json;data/multitenancy/tenant_e.json
 # Log all requests and responses for debug purposes, by default false
 log.all.requests.responses=false
+# Identity
+identity.feature.toggle=true
+identity.base.uri=http://${environment.name}-bbiam.backbase.test:8180/
+identity.realm=backbase
+identity.client=hybrid-flow

--- a/src/main/resources/data.properties
+++ b/src/main/resources/data.properties
@@ -60,6 +60,6 @@ multi.tenancy.legal.entities.with.users.json=data/multitenancy/tenant_a.json;dat
 # Log all requests and responses for debug purposes, by default false
 log.all.requests.responses=false
 # Identity
-identity.feature.toggle=true
+identity.feature.toggle=false
 identity.realm=backbase
 identity.client=hybrid-flow

--- a/src/main/resources/data.properties
+++ b/src/main/resources/data.properties
@@ -61,6 +61,5 @@ multi.tenancy.legal.entities.with.users.json=data/multitenancy/tenant_a.json;dat
 log.all.requests.responses=false
 # Identity
 identity.feature.toggle=true
-identity.base.uri=http://${environment.name}-bbiam.backbase.test:8180/
 identity.realm=backbase
 identity.client=hybrid-flow


### PR DESCRIPTION
Identity support for bb-fuel.

Tested identity and non-identity on AWS environment.
For PCF, K8S and localhost, just asked/guessed the endpoints.