### PR TITLE
Feature/neop 481 add cad currency for ach debit

### DIFF
--- a/src/main/java/com/backbase/ct/bbfuel/client/productsummary/ProductSummaryPresentationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/productsummary/ProductSummaryPresentationRestClient.java
@@ -83,7 +83,7 @@ public class ProductSummaryPresentationRestClient extends RestClient {
     }
 
     public List<ArrangementsByBusinessFunctionGetResponseBody> getAchDebitArrangements() {
-        return Arrays.asList(getProductSummaryContextArrangements(new ProductSummaryQueryParameters()
+        return Arrays.stream(getProductSummaryContextArrangements(new ProductSummaryQueryParameters()
             .withBusinessFunction(ACH_DEBIT_FUNCTION_NAME)
             .withResourceName(PAYMENTS_RESOURCE_NAME)
             .withPrivilege(PRIVILEGE_CREATE)
@@ -94,7 +94,12 @@ public class ProductSummaryPresentationRestClient extends RestClient {
             .then()
             .statusCode(SC_OK)
             .extract()
-            .as(ArrangementsByBusinessFunctionGetResponseBody[].class));
+            .as(ArrangementsByBusinessFunctionGetResponseBody[].class))
+                .filter(arrangement -> isValidCurrencyForAchDebit(arrangement.getCurrency())).collect(Collectors.toList());
+    }
+
+    private static boolean isValidCurrencyForAchDebit(String currency) {
+        return currency.equals("USD") || currency.equals("CAD");
     }
 
     private Response getProductSummaryContextArrangements(ProductSummaryQueryParameters queryParameters) {

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/PaymentsConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/PaymentsConfigurator.java
@@ -53,8 +53,8 @@ public class PaymentsConfigurator {
             .generateRandomNumberInRange(globalProperties.getInt(CommonConstants.PROPERTY_PAYMENTS_MIN),
                 globalProperties.getInt(CommonConstants.PROPERTY_PAYMENTS_MAX));
 
-        if (sepaCtArrangements.size() != 0 && usDomesticWireArrangements.size() != 0
-            && achDebitArrangements.size() != 0) {
+        if (!sepaCtArrangements.isEmpty() && !usDomesticWireArrangements.isEmpty()
+            && !achDebitArrangements.isEmpty()) {
 
             IntStream.range(0, randomAmount).parallel().forEach(randomNumber -> {
                 String paymentType = getRandomFromList(PAYMENT_TYPES);
@@ -69,7 +69,7 @@ public class PaymentsConfigurator {
                 }
 
                 InitiatePaymentOrder initiatePaymentOrder = PaymentsDataGenerator
-                    .generateInitiatePaymentOrder(randomArrangement.getId(), paymentType);
+                    .generateInitiatePaymentOrder(randomArrangement.getId(), randomArrangement.getCurrency(), paymentType);
                 paymentOrderPresentationRestClient.initiatePaymentOrder(initiatePaymentOrder)
                     .then()
                     .statusCode(SC_ACCEPTED);

--- a/src/main/java/com/backbase/ct/bbfuel/data/PaymentsDataGenerator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/PaymentsDataGenerator.java
@@ -1,5 +1,6 @@
 package com.backbase.ct.bbfuel.data;
 
+import static com.backbase.ct.bbfuel.data.CommonConstants.PAYMENT_TYPE_ACH_DEBIT;
 import static com.backbase.ct.bbfuel.data.CommonConstants.PAYMENT_TYPE_SEPA_CREDIT_TRANSFER;
 import static com.backbase.ct.bbfuel.util.CommonHelpers.getRandomFromEnumValues;
 import static com.backbase.ct.bbfuel.util.CommonHelpers.getRandomFromList;
@@ -44,14 +45,16 @@ public class PaymentsDataGenerator {
         Schedule schedule = null;
         Bank creditorBank = null;
         Bank correspondentBank = null;
-        Currency currency = new Currency().withAmount(CommonHelpers.generateRandomAmountInRange(1000L, 99999L));
+        Currency currency = new Currency().withAmount(CommonHelpers.generateRandomAmountInRange(1000L, 99999L))
+            .withCurrencyCode(generateCurrencyCode(paymentType));
         Identification identification;
 
         if (paymentMode.equals(IdentifiedPaymentOrder.PaymentMode.RECURRING)) {
             schedule = new Schedule()
                 .withStartDate(new SimpleDateFormat("yyyy-MM-dd").format(new Date()))
                 .withEvery(getRandomFromEnumValues(Schedule.Every.values()))
-                .withNonWorkingDayExecutionStrategy(getRandomFromEnumValues(Schedule.NonWorkingDayExecutionStrategy.values()))
+                .withNonWorkingDayExecutionStrategy(
+                    getRandomFromEnumValues(Schedule.NonWorkingDayExecutionStrategy.values()))
                 .withTransferFrequency(
                     getRandomFromEnumValues(Schedule.TransferFrequency.values()))
                 .withOn(CommonHelpers.generateRandomNumberInRange(1, 7))
@@ -59,12 +62,10 @@ public class PaymentsDataGenerator {
         }
 
         if (PAYMENT_TYPE_SEPA_CREDIT_TRANSFER.equals(paymentType)) {
-            currency.setCurrencyCode("EUR");
             identification = generateIbanIdentification();
         } else {
             creditorBank = generateCreditorBank();
             correspondentBank = generateCorrespondentBank();
-            currency.setCurrencyCode("USD");
             identification = generateBbanIdentification();
         }
 
@@ -131,5 +132,15 @@ public class PaymentsDataGenerator {
                 .withTown(faker.address().city())
                 .withCountry(faker.address().countryCode())
                 .withCountrySubDivision(faker.address().state()));
+    }
+
+    private static String generateCurrencyCode(String paymentType) {
+        if (PAYMENT_TYPE_SEPA_CREDIT_TRANSFER.equals(paymentType)) {
+            return "EUR";
+        }
+        if (PAYMENT_TYPE_ACH_DEBIT.equals(paymentType) && random.nextBoolean()) {
+            return "CAD";
+        }
+        return "USD";
     }
 }

--- a/src/main/java/com/backbase/ct/bbfuel/data/PaymentsDataGenerator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/PaymentsDataGenerator.java
@@ -39,14 +39,13 @@ public class PaymentsDataGenerator {
             "241273188", "244077815", "241075153", "073911870", "303184610", "303986151", "263277887", "103101848",
             "103101013", "303986096");
 
-    public static InitiatePaymentOrder generateInitiatePaymentOrder(String debtorArrangementId, String paymentType) {
+    public static InitiatePaymentOrder generateInitiatePaymentOrder(String debtorArrangementId, String debtorarrangementCurrency, String paymentType) {
         IdentifiedPaymentOrder.PaymentMode paymentMode = IdentifiedPaymentOrder.PaymentMode.values()[random
             .nextInt(IdentifiedPaymentOrder.PaymentMode.values().length)];
         Schedule schedule = null;
         Bank creditorBank = null;
         Bank correspondentBank = null;
-        Currency currency = new Currency().withAmount(CommonHelpers.generateRandomAmountInRange(1000L, 99999L))
-            .withCurrencyCode(generateCurrencyCode(paymentType));
+        Currency currency = new Currency().withAmount(CommonHelpers.generateRandomAmountInRange(1000L, 99999L));
         Identification identification;
 
         if (paymentMode.equals(IdentifiedPaymentOrder.PaymentMode.RECURRING)) {
@@ -62,10 +61,16 @@ public class PaymentsDataGenerator {
         }
 
         if (PAYMENT_TYPE_SEPA_CREDIT_TRANSFER.equals(paymentType)) {
+            currency.setCurrencyCode("EUR");
             identification = generateIbanIdentification();
+        } else if (PAYMENT_TYPE_ACH_DEBIT.equals(paymentType)) {
+            creditorBank = generateCreditorBank();
+            currency.setCurrencyCode(debtorarrangementCurrency);
+            identification = generateBbanIdentification();
         } else {
             creditorBank = generateCreditorBank();
             correspondentBank = generateCorrespondentBank();
+            currency.setCurrencyCode("USD");
             identification = generateBbanIdentification();
         }
 
@@ -132,15 +137,5 @@ public class PaymentsDataGenerator {
                 .withTown(faker.address().city())
                 .withCountry(faker.address().countryCode())
                 .withCountrySubDivision(faker.address().state()));
-    }
-
-    private static String generateCurrencyCode(String paymentType) {
-        if (PAYMENT_TYPE_SEPA_CREDIT_TRANSFER.equals(paymentType)) {
-            return "EUR";
-        }
-        if (PAYMENT_TYPE_ACH_DEBIT.equals(paymentType) && random.nextBoolean()) {
-            return "CAD";
-        }
-        return "USD";
     }
 }


### PR DESCRIPTION
- Payment ingestion is refactored with CAD currency account and CAD currency amount if payment is ACH debit.
- getArrangements for ACH Debit is filtered by supported currencies (CAD and USD).

These changes will help to have debits with CAD and USD originator accounts and same currency for amount.

