### PR TITLE
Retail Service Agreements json

### DIFF
--- a/src/main/resources/data/service-agreements-retail.json
+++ b/src/main/resources/data/service-agreements-retail.json
@@ -1,0 +1,18 @@
+[
+  {
+    "participants": [
+      {
+        "admins": [
+          "admin"
+        ],
+        "users": [
+          "user",
+          "designer",
+          "manager"
+        ],
+        "sharingUsers": true,
+        "sharingAccounts": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adding retail specific service agreements json to avoid failures due to lack of ingested users;

This file need to be specified by adding the additional argument: -Dservice.agreements.json=data/service-agreements-retail.json

Evidence:
<img width="1679" alt="Screen Shot 2020-03-25 at 10 56 22" src="https://user-images.githubusercontent.com/47349985/77525378-3b23d380-6e89-11ea-99c2-a2b6da2e3bb7.png">
<img width="1680" alt="Screen Shot 2020-03-25 at 11 10 38" src="https://user-images.githubusercontent.com/47349985/77525416-4aa31c80-6e89-11ea-939f-6dfa3fc16c74.png">
