### PR TITLE
Transactions base path for the rest client is not `client-api`

### DIFF
--- a/src/main/java/com/backbase/ct/bbfuel/client/transaction/TransactionsIntegrationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/transaction/TransactionsIntegrationRestClient.java
@@ -17,13 +17,11 @@ public class TransactionsIntegrationRestClient extends RestClient {
     private final BbFuelConfiguration config;
 
     private static final String SERVICE_VERSION = "v2";
-    private static final String CLIENT_API = "client-api";
     private static final String ENDPOINT_TRANSACTIONS = "/transactions";
 
     @PostConstruct
     public void init() {
         setBaseUri(config.getDbs().getTransactions());
-        setInitialPath(CLIENT_API);
         setVersion(SERVICE_VERSION);
     }
 

--- a/src/main/java/com/backbase/ct/bbfuel/client/transaction/TransactionsIntegrationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/transaction/TransactionsIntegrationRestClient.java
@@ -17,13 +17,13 @@ public class TransactionsIntegrationRestClient extends RestClient {
     private final BbFuelConfiguration config;
 
     private static final String SERVICE_VERSION = "v2";
-    private static final String CLIENT_API = "service-api";
+    private static final String BASE_PATH = "service-api";
     private static final String ENDPOINT_TRANSACTIONS = "/transactions";
 
     @PostConstruct
     public void init() {
         setBaseUri(config.getDbs().getTransactions());
-        setInitialPath(CLIENT_API);
+        setInitialPath(BASE_PATH);
         setVersion(SERVICE_VERSION);
     }
 

--- a/src/main/java/com/backbase/ct/bbfuel/client/transaction/TransactionsIntegrationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/transaction/TransactionsIntegrationRestClient.java
@@ -17,11 +17,13 @@ public class TransactionsIntegrationRestClient extends RestClient {
     private final BbFuelConfiguration config;
 
     private static final String SERVICE_VERSION = "v2";
+    private static final String CLIENT_API = "service-api";
     private static final String ENDPOINT_TRANSACTIONS = "/transactions";
 
     @PostConstruct
     public void init() {
         setBaseUri(config.getDbs().getTransactions());
+        setInitialPath(CLIENT_API);
         setVersion(SERVICE_VERSION);
     }
 


### PR DESCRIPTION
In the following commit from @richard-blank, `client-api` added to the transactions rest-client as the initial base path which is not correct. This endpoint is not available for clients.

https://github.com/Backbase/bb-fuel/commit/be5b1e42f5d23c0bb72910b2fdaada57336689e7

https://docs.backbase.com/extranet/technical-docs/endpoints/2.17.3/v2/dbs_service_api.html#transactions__transaction_integration_external_inbound_spec_service_api_v2_transactions_post