### PR TITLE
Remove the base path

### DIFF
--- a/src/main/java/com/backbase/ct/bbfuel/client/transaction/TransactionsIntegrationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/transaction/TransactionsIntegrationRestClient.java
@@ -17,13 +17,11 @@ public class TransactionsIntegrationRestClient extends RestClient {
     private final BbFuelConfiguration config;
 
     private static final String SERVICE_VERSION = "v2";
-    private static final String BASE_PATH = "service-api";
     private static final String ENDPOINT_TRANSACTIONS = "/transactions";
 
     @PostConstruct
     public void init() {
         setBaseUri(config.getDbs().getTransactions());
-        setInitialPath(BASE_PATH);
         setVersion(SERVICE_VERSION);
     }
 


### PR DESCRIPTION
This is the case:
- raml spec says /client-api
- docs says /service-api
- code publishes the endpoint in /

So, for now, we should just remove the base path to make it work.