### PR TITLE
Parallel ingestion dropped for transaction ingestion

### DIFF
--- a/src/main/java/com/backbase/ct/bbfuel/setup/AccessControlSetup.java
+++ b/src/main/java/com/backbase/ct/bbfuel/setup/AccessControlSetup.java
@@ -242,9 +242,8 @@ public class AccessControlSetup extends BaseSetup {
 
     private void ingestTransactions(List<ArrangementId> arrangementIds, boolean isRetail) {
         if (this.globalProperties.getBoolean(PROPERTY_INGEST_TRANSACTIONS)) {
-            arrangementIds.parallelStream()
-                .forEach(arrangementId -> this.transactionsConfigurator
-                    .ingestTransactionsByArrangement(arrangementId.getExternalArrangementId(), isRetail));
+            arrangementIds.forEach(arrangementId -> this.transactionsConfigurator
+                .ingestTransactionsByArrangement(arrangementId.getExternalArrangementId(), isRetail));
         }
     }
 
@@ -300,7 +299,8 @@ public class AccessControlSetup extends BaseSetup {
                     .findAssignedProductGroupsIds(externalServiceAgreementId, user);
                 List<IntegrationIdentifier> dataGroupIdentifiers = new ArrayList<>();
 
-                dataGroupIds.forEach(dataGroupId -> dataGroupIdentifiers.add(new IntegrationIdentifier().withIdIdentifier(dataGroupId)));
+                dataGroupIds.forEach(
+                    dataGroupId -> dataGroupIdentifiers.add(new IntegrationIdentifier().withIdIdentifier(dataGroupId)));
 
                 functionGroupDataGroups.add(new IntegrationFunctionGroupDataGroup()
                     .withFunctionGroupIdentifier(


### PR DESCRIPTION
Because of the performance improvements that we did in transactions, parallel ingestion in MySQL started to fail some times because of the deadlock in MySQL side. We can use the normal ingestion for transactions from now on. It has good performance and also other huge improvements are coming. This will prevent the MySQL error.