### PR TITLE
BB_FUEL_VERSION job parameter at the top

### DIFF
--- a/jenkins/bb-fuel-minimal.groovy
+++ b/jenkins/bb-fuel-minimal.groovy
@@ -4,6 +4,7 @@ pipeline {
     agent any
 
     parameters {
+        string(name: 'BB_FUEL_VERSION', defaultValue: 'latest', description: 'Use latest to get the latest version or add an existing version, and only the version number. E.g: 2.6.9. \n You can see the existing versions at: https://github.com/Backbase/bb-fuel/releases')
         choice(name: 'SPRING_PROFILES_ACTIVE', choices: 'k8s\naws\npcf', description: 'Select the profile to operate.\nK8s (default):\nKubernetes requires environment name\n\nAWS: \n Requires environment name\n\nPCF: \nRequires space name (environment name will be ignored)')
         string(name: 'ENVIRONMENT_NAME', defaultValue: '00.dbs', description: 'K8S example: 42.dbs\n\nAutoconfig example: frosty-snow-99\nRead before running: https://github.com/Backbase/bb-fuel/blob/master/README.md')
         string(name: 'PCF_SPACE', defaultValue: 'your-space', description: 'Required only for PCF. Space name, example: approvals\nRead before running: https://github.com/Backbase/bb-fuel/blob/master/README.md')
@@ -31,7 +32,6 @@ pipeline {
         booleanParam(name: 'IDENTITY_FEATURE_TOGGLE', defaultValue: false, description: 'Use identity')
         string(name: 'IDENTITY_REALM', defaultValue: 'backbase', description: 'Identity realm')
         string(name: 'IDENTITY_CLIENT', defaultValue: 'bb-tooling-client', description: 'AWS: hybrid-flow\nK8S: bb-tooling-client')
-        string(name: 'BB_FUEL_VERSION', defaultValue: 'latest', description: '')
         booleanParam(name: 'PRERELEASE', defaultValue: false, description: 'Only applicable if BB_FUEL_VERSION = latest')
         booleanParam(name: 'HEALTHCHECK_USE_ACTUATOR', defaultValue: true, description: 'Should be false if BOM version <= 2.16.4')
         string(name: 'ADDITIONAL_ARGUMENTS', defaultValue: '-Dtransactions.min=0 -Dtransactions.max=0 -Djob.profiles.json=data/minimal-bank/job-profiles.json -Dproducts.json=data/minimal-bank/products.json -Dproduct.group.seed.json=data/minimal-bank/product-group-seed.json -Dlegal.entities.with.users.json=data/minimal-bank/legal-entities-with-users.json', description: 'Additional command line arguments for BB-FUEL Minimal')

--- a/jenkins/bb-fuel-minimal.groovy
+++ b/jenkins/bb-fuel-minimal.groovy
@@ -5,6 +5,7 @@ pipeline {
 
     parameters {
         string(name: 'BB_FUEL_VERSION', defaultValue: 'latest', description: 'Use latest to get the latest version or add an existing version, and only the version number. E.g: 2.6.9. \n You can see the existing versions at: https://github.com/Backbase/bb-fuel/releases')
+        booleanParam(name: 'PRERELEASE', defaultValue: false, description: 'Only applicable if BB_FUEL_VERSION = latest')
         choice(name: 'SPRING_PROFILES_ACTIVE', choices: 'k8s\naws\npcf', description: 'Select the profile to operate.\nK8s (default):\nKubernetes requires environment name\n\nAWS: \n Requires environment name\n\nPCF: \nRequires space name (environment name will be ignored)')
         string(name: 'ENVIRONMENT_NAME', defaultValue: '00.dbs', description: 'K8S example: 42.dbs\n\nAutoconfig example: frosty-snow-99\nRead before running: https://github.com/Backbase/bb-fuel/blob/master/README.md')
         string(name: 'PCF_SPACE', defaultValue: 'your-space', description: 'Required only for PCF. Space name, example: approvals\nRead before running: https://github.com/Backbase/bb-fuel/blob/master/README.md')
@@ -32,7 +33,6 @@ pipeline {
         booleanParam(name: 'IDENTITY_FEATURE_TOGGLE', defaultValue: false, description: 'Use identity')
         string(name: 'IDENTITY_REALM', defaultValue: 'backbase', description: 'Identity realm')
         string(name: 'IDENTITY_CLIENT', defaultValue: 'bb-tooling-client', description: 'AWS: hybrid-flow\nK8S: bb-tooling-client')
-        booleanParam(name: 'PRERELEASE', defaultValue: false, description: 'Only applicable if BB_FUEL_VERSION = latest')
         booleanParam(name: 'HEALTHCHECK_USE_ACTUATOR', defaultValue: true, description: 'Should be false if BOM version <= 2.16.4')
         string(name: 'ADDITIONAL_ARGUMENTS', defaultValue: '-Dtransactions.min=0 -Dtransactions.max=0 -Djob.profiles.json=data/minimal-bank/job-profiles.json -Dproducts.json=data/minimal-bank/products.json -Dproduct.group.seed.json=data/minimal-bank/product-group-seed.json -Dlegal.entities.with.users.json=data/minimal-bank/legal-entities-with-users.json', description: 'Additional command line arguments for BB-FUEL Minimal')
         booleanParam(name: 'MULTI_TENANCY_ENVIRONMENT', defaultValue: false, description: 'Enable multi tenancy')

--- a/jenkins/bb-fuel.groovy
+++ b/jenkins/bb-fuel.groovy
@@ -4,6 +4,7 @@ pipeline {
     agent any
 
     parameters {
+        string(name: 'BB_FUEL_VERSION', defaultValue: 'latest', description: 'Use latest to get the latest version or add an existing version, and only the version number. E.g: 2.6.9. \n You can see the existing versions at: https://github.com/Backbase/bb-fuel/releases')
         choice(name: 'SPRING_PROFILES_ACTIVE', choices: 'k8s\nk8s-3ang\naws\npcf', description: 'Select the profile to operate.\nK8s (default):\nKubernetes requires environment name\n\nk8s-3ang: \nUsed for DBS with triangular services only\n\nAWS: \n Requires environment name\n\nPCF: \nRequires space name (environment name will be ignored)')
         string(name: 'ENVIRONMENT_NAME', defaultValue: '00.dbs', description: 'K8S example: 42.dbs\n\nAutoconfig example: frosty-snow-99\nRead before running: https://github.com/Backbase/bb-fuel/blob/master/README.md')
         string(name: 'PCF_SPACE', defaultValue: 'your-space', description: 'Required only for PCF. Space name, example: approvals\nRead before running: https://github.com/Backbase/bb-fuel/blob/master/README.md')
@@ -31,7 +32,6 @@ pipeline {
         booleanParam(name: 'IDENTITY_FEATURE_TOGGLE', defaultValue: false, description: 'Use identity')
         string(name: 'IDENTITY_REALM', defaultValue: 'backbase', description: 'Identity realm')
         string(name: 'IDENTITY_CLIENT', defaultValue: 'bb-tooling-client', description: 'AWS: hybrid-flow\nK8S: bb-tooling-client')
-        string(name: 'BB_FUEL_VERSION', defaultValue: 'latest', description: '')
         booleanParam(name: 'PRERELEASE', defaultValue: false, description: 'Only applicable if BB_FUEL_VERSION = latest')
         booleanParam(name: 'HEALTHCHECK_USE_ACTUATOR', defaultValue: true, description: 'Should be false if BOM version <= 2.16.4')
         string(name: 'ADDITIONAL_ARGUMENTS', defaultValue: '', description: 'Additional command line arguments')

--- a/jenkins/bb-fuel.groovy
+++ b/jenkins/bb-fuel.groovy
@@ -5,6 +5,7 @@ pipeline {
 
     parameters {
         string(name: 'BB_FUEL_VERSION', defaultValue: 'latest', description: 'Use latest to get the latest version or add an existing version, and only the version number. E.g: 2.6.9. \n You can see the existing versions at: https://github.com/Backbase/bb-fuel/releases')
+        booleanParam(name: 'PRERELEASE', defaultValue: false, description: 'Only applicable if BB_FUEL_VERSION = latest')
         choice(name: 'SPRING_PROFILES_ACTIVE', choices: 'k8s\nk8s-3ang\naws\npcf', description: 'Select the profile to operate.\nK8s (default):\nKubernetes requires environment name\n\nk8s-3ang: \nUsed for DBS with triangular services only\n\nAWS: \n Requires environment name\n\nPCF: \nRequires space name (environment name will be ignored)')
         string(name: 'ENVIRONMENT_NAME', defaultValue: '00.dbs', description: 'K8S example: 42.dbs\n\nAutoconfig example: frosty-snow-99\nRead before running: https://github.com/Backbase/bb-fuel/blob/master/README.md')
         string(name: 'PCF_SPACE', defaultValue: 'your-space', description: 'Required only for PCF. Space name, example: approvals\nRead before running: https://github.com/Backbase/bb-fuel/blob/master/README.md')
@@ -32,7 +33,6 @@ pipeline {
         booleanParam(name: 'IDENTITY_FEATURE_TOGGLE', defaultValue: false, description: 'Use identity')
         string(name: 'IDENTITY_REALM', defaultValue: 'backbase', description: 'Identity realm')
         string(name: 'IDENTITY_CLIENT', defaultValue: 'bb-tooling-client', description: 'AWS: hybrid-flow\nK8S: bb-tooling-client')
-        booleanParam(name: 'PRERELEASE', defaultValue: false, description: 'Only applicable if BB_FUEL_VERSION = latest')
         booleanParam(name: 'HEALTHCHECK_USE_ACTUATOR', defaultValue: true, description: 'Should be false if BOM version <= 2.16.4')
         string(name: 'ADDITIONAL_ARGUMENTS', defaultValue: '', description: 'Additional command line arguments')
         booleanParam(name: 'MULTI_TENANCY_ENVIRONMENT', defaultValue: false, description: 'Enable multi tenancy')


### PR DESCRIPTION
This PR adds the `BB_FUEL_VERSION` parameter at the top to make it easier for the people using it if they have a problem with the latest version, so they can set any other previous one.