### PR TITLE
Beck environments fix

### DIFF
--- a/jenkins/bb-fuel-minimal.groovy
+++ b/jenkins/bb-fuel-minimal.groovy
@@ -55,6 +55,7 @@ pipeline {
                             bbFuelVersion: params.BB_FUEL_VERSION,
                             prerelease: params.PRERELEASE,
                             additionalArguments: "-Dbb-fuel.platform.infra=http://${params.ENVIRONMENT_NAME}-${params.INFRA_BASE_URI} " +
+                                    "-Denvironment.domain=${params.INFRA_BASE_URI} " +
                                     "-Dingest.access.control=${params.INGEST_ACCESS_CONTROL} " +
                                     "-Dingest.custom.service.agreements=${params.INGEST_CUSTOM_SERVICE_AGREEMENTS} " +
                                     "-Dingest.balance.history=${params.INGEST_BALANCE_HISTORY} " +

--- a/jenkins/bb-fuel.groovy
+++ b/jenkins/bb-fuel.groovy
@@ -55,6 +55,7 @@ pipeline {
                             bbFuelVersion: params.BB_FUEL_VERSION,
                             prerelease: params.PRERELEASE,
                             additionalArguments: "-Dbb-fuel.platform.infra=http://${params.ENVIRONMENT_NAME}-${params.INFRA_BASE_URI} " +
+                                    "-Denvironment.domain=${params.INFRA_BASE_URI} " +
                                     "-Dingest.access.control=${params.INGEST_ACCESS_CONTROL} " +
                                     "-Dingest.custom.service.agreements=${params.INGEST_CUSTOM_SERVICE_AGREEMENTS} " +
                                     "-Dingest.balance.history=${params.INGEST_BALANCE_HISTORY} " +


### PR DESCRIPTION
-  Passing INFRA_BASE_URI value as `environment.domain` variable, in order to be able to override the default `backbase.test`