### PR TITLE
Updating transactions generation to support US specific data

### DIFF
--- a/src/main/java/com/backbase/ct/bbfuel/configurator/TransactionsConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/TransactionsConfigurator.java
@@ -63,7 +63,7 @@ public class TransactionsConfigurator {
         } else {
             IntStream.range(0, randomAmount).parallel()
                     .forEach(randomNumber -> transactions.add(
-                            TransactionsDataGenerator.generateTransactionsPostRequestBody(externalArrangementId, isRetail, finalCategories)));
+                            TransactionsDataGenerator.generateTransactionsPostRequestBody(externalArrangementId)));
         }
         transactionsIntegrationRestClient.ingestTransactions(transactions)
             .then()

--- a/src/main/java/com/backbase/ct/bbfuel/data/CommonConstants.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/CommonConstants.java
@@ -92,6 +92,7 @@ public final class CommonConstants {
     // Transactions
     public static final String PROPERTY_TRANSACTIONS_DATA_JSON = "transactions.data.json";
     public static final String PROPERTY_TRANSACTIONS_CHECK_IMAGES_DATA_JSON = "transactions-check-images.data.json";
+    public static final String PROPERTY_TRANSACTIONS_BUSINESS_CURRENCY = "transactions.business.currency";
 
     // Identity
     public static final String PROPERTY_IDENTITY_FEATURE_TOGGLE = "identity.feature.toggle";

--- a/src/main/resources/data.properties
+++ b/src/main/resources/data.properties
@@ -21,6 +21,7 @@ ingest.transactions=false
 use.pfm.categories.for.transactions=false
 transactions.min=10
 transactions.max=30
+transactions.business.currency=EUR
 # Ingest approvals
 ingest.approvals.for.payments=false
 ingest.approvals.for.contacts=false

--- a/src/main/resources/data/us-productized-dataset/us-productized-data.properties
+++ b/src/main/resources/data/us-productized-dataset/us-productized-data.properties
@@ -21,6 +21,7 @@ ingest.transactions=false
 use.pfm.categories.for.transactions=false
 transactions.min=10
 transactions.max=30
+transactions.business.currency=USD
 # Ingest approvals
 ingest.approvals.for.payments=false
 ingest.approvals.for.contacts=false


### PR DESCRIPTION
1. Adding ability to select transaction currency for business from properties
2. Added USD as default transaction currency for us-specific dataset
3. Simplified transaction request body generation to use only with business data, since retail is handled by transaction-retail.json data seed file