### PR TITLE
ID-2527 bb-fuel Integration with Identity

### DIFF
--- a/src/main/java/com/backbase/ct/bbfuel/client/common/RestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/common/RestClient.java
@@ -69,7 +69,6 @@ public class RestClient {
     private static final String ACTUATOR_HEALTH_PATH = "/actuator/health";
     private static final String SERVER_STATUS_UP = "UP";
     private static final String TENANT_HEADER_NAME = "X-TID";
-
     protected static GlobalProperties globalProperties = GlobalProperties.getInstance();
 
     @Getter

--- a/src/main/java/com/backbase/ct/bbfuel/client/legalentity/LegalEntityPresentationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/legalentity/LegalEntityPresentationRestClient.java
@@ -5,8 +5,8 @@ import static org.apache.http.HttpStatus.SC_OK;
 import com.backbase.ct.bbfuel.client.common.RestClient;
 import com.backbase.ct.bbfuel.config.BbFuelConfiguration;
 import com.backbase.presentation.accessgroup.rest.spec.v2.accessgroups.serviceagreements.ServiceAgreementGetResponseBody;
+import com.backbase.presentation.legalentity.rest.spec.v2.legalentities.LegalEntityByExternalIdGetResponseBody;
 import com.backbase.presentation.legalentity.rest.spec.v2.legalentities.LegalEntityByIdGetResponseBody;
-import io.restassured.response.Response;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -31,19 +31,24 @@ public class LegalEntityPresentationRestClient extends RestClient {
         setInitialPath(config.getDbsServiceNames().getLegalentity() + "/" + CLIENT_API);
     }
 
-    public Response retrieveLegalEntityByExternalId(String externalLegalEntityId) {
+    public LegalEntityByIdGetResponseBody retrieveLegalEntityByLegalEntityId(String internalLegalEntityId){
         return requestSpec()
-            .get(String.format(getPath(ENDPOINT_EXTERNAL), externalLegalEntityId));
-    }
-
-    public LegalEntityByIdGetResponseBody retrieveLegalEntityByLegalEntityId(String internalLegalEntityId) {
-        return requestSpec()
-            .get(getPath(ENDPOINT_LEGAL_ENTITIES + internalLegalEntityId))
+            .get(getPath(ENDPOINT_LEGAL_ENTITIES + "/" + internalLegalEntityId))
             .then()
             .statusCode(SC_OK)
             .extract()
             .as(LegalEntityByIdGetResponseBody.class);
     }
+
+    public LegalEntityByExternalIdGetResponseBody retrieveLegalEntityByExternalId(String externalLegalEntityId) {
+        return requestSpec()
+            .get(String.format(getPath(ENDPOINT_EXTERNAL), externalLegalEntityId))
+            .then()
+            .statusCode(SC_OK)
+            .extract()
+            .as(LegalEntityByExternalIdGetResponseBody.class);
+    }
+
 
     public ServiceAgreementGetResponseBody getMasterServiceAgreementOfLegalEntity(String internalLegalEntityId) {
         return requestSpec()

--- a/src/main/java/com/backbase/ct/bbfuel/client/user/UserIntegrationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/user/UserIntegrationRestClient.java
@@ -1,7 +1,9 @@
 package com.backbase.ct.bbfuel.client.user;
 
 import static com.backbase.ct.bbfuel.util.ResponseUtils.isBadRequestException;
+import static com.backbase.ct.bbfuel.util.ResponseUtils.isConflictException;
 import static org.apache.http.HttpStatus.SC_CREATED;
+import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_IDENTITY_FEATURE_TOGGLE;
 
 import com.backbase.ct.bbfuel.client.common.RestClient;
 import com.backbase.ct.bbfuel.config.BbFuelConfiguration;
@@ -21,6 +23,7 @@ public class UserIntegrationRestClient extends RestClient {
     private final BbFuelConfiguration config;
     private static final String SERVICE_VERSION = "v2";
     private static final String ENDPOINT_USERS = "/users";
+    private static final String ENDPOINT_IDENTITIES = ENDPOINT_USERS + "/identities";
 
     @PostConstruct
     public void init() {
@@ -28,24 +31,46 @@ public class UserIntegrationRestClient extends RestClient {
         setVersion(SERVICE_VERSION);
     }
 
-    public void ingestUserAndLogResponse(UsersPostRequestBody user) {
-        Response response = ingestUser(user);
+    public void ingestAdminAndLogResponse(UsersPostRequestBody user) {
 
-        if (isBadRequestException(response, "User already exists")) {
+        Response response;
+
+        if (this.globalProperties.getBoolean(PROPERTY_IDENTITY_FEATURE_TOGGLE)) {
+            response = importUserIdentity(user);
+        } else {
+            response = ingestUser(user);
+        }
+
+        if (isBadRequestException(response, "User already exists") || isConflictException(response, "User already exists")) {
             log.info("User [{}] already exists, skipped ingesting this user", user.getExternalId());
         } else if (response.statusCode() == SC_CREATED) {
             log.info("User [{}] ingested under legal entity [{}]",
                 user.getExternalId(), user.getLegalEntityExternalId());
         } else {
+            log.info("User [{}] could not be ingested", user.getExternalId());
             response.then()
                 .statusCode(SC_CREATED);
         }
     }
 
-    private Response ingestUser(UsersPostRequestBody body) {
+    public Response ingestUser(UsersPostRequestBody body) {
         return requestSpec()
             .contentType(ContentType.JSON)
             .body(body)
             .post(getPath(ENDPOINT_USERS));
+    }
+
+    public Response importUserIdentity(UsersPostRequestBody body){
+
+        UsersPostRequestBody importBody = new UsersPostRequestBody();
+
+        importBody
+            .withExternalId(body.getExternalId())
+            .withLegalEntityExternalId(body.getLegalEntityExternalId());
+
+        return requestSpec()
+            .contentType(ContentType.JSON)
+            .body(importBody)
+            .post(getPath(ENDPOINT_IDENTITIES));
     }
 }

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/LegalEntitiesAndUsersConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/LegalEntitiesAndUsersConfigurator.java
@@ -1,18 +1,35 @@
 package com.backbase.ct.bbfuel.configurator;
 
 import static com.backbase.ct.bbfuel.data.CommonConstants.EXTERNAL_ROOT_LEGAL_ENTITY_ID;
+import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_IDENTITY_FEATURE_TOGGLE;
+import static com.backbase.ct.bbfuel.util.ResponseUtils.isBadRequestException;
+import static com.backbase.ct.bbfuel.util.ResponseUtils.isConflictException;
+import static com.backbase.ct.bbfuel.util.ResponseUtils.isNotFoundException;
+import static org.apache.http.HttpStatus.SC_CREATED;
+
 
 import com.backbase.ct.bbfuel.client.accessgroup.UserContextPresentationRestClient;
 import com.backbase.ct.bbfuel.client.common.LoginRestClient;
+import com.backbase.ct.bbfuel.client.legalentity.LegalEntityPresentationRestClient;
 import com.backbase.ct.bbfuel.client.user.UserIntegrationRestClient;
+import com.backbase.ct.bbfuel.client.user.UserPresentationRestClient;
 import com.backbase.ct.bbfuel.data.LegalEntitiesAndUsersDataGenerator;
 import com.backbase.ct.bbfuel.dto.LegalEntityWithUsers;
+
+
 import com.backbase.ct.bbfuel.dto.User;
 import com.backbase.ct.bbfuel.service.LegalEntityService;
+import com.backbase.ct.bbfuel.util.GlobalProperties;
+import com.backbase.dbs.user.integration.rest.spec.v2.users.UsersPostRequestBody;
+
+
 import com.backbase.integration.legalentity.rest.spec.v2.legalentities.LegalEntitiesPostRequestBody;
+import io.restassured.response.Response;
+import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LegalEntitiesAndUsersConfigurator {
@@ -20,8 +37,12 @@ public class LegalEntitiesAndUsersConfigurator {
     private final LoginRestClient loginRestClient;
     private final UserContextPresentationRestClient userContextPresentationRestClient;
     private final UserIntegrationRestClient userIntegrationRestClient;
+    private final UserPresentationRestClient userPresentationRestClient;
+    private final LegalEntityPresentationRestClient legalEntityPresentationRestClient;
     private final LegalEntityService legalEntityService;
     private final ServiceAgreementsConfigurator serviceAgreementsConfigurator;
+
+    protected static GlobalProperties globalProperties = GlobalProperties.getInstance();
 
     /**
      * Dispatch the creation of legal entity depending whether given legalEntityWithUsers is a root entity.
@@ -42,7 +63,7 @@ public class LegalEntitiesAndUsersConfigurator {
             .updateMasterServiceAgreementWithExternalIdByLegalEntity(externalLegalEntityId);
 
         User admin = root.getUsers().get(0);
-        this.userIntegrationRestClient.ingestUserAndLogResponse(LegalEntitiesAndUsersDataGenerator
+        this.userIntegrationRestClient.ingestAdminAndLogResponse(LegalEntitiesAndUsersDataGenerator
             .generateUsersPostRequestBody(admin, EXTERNAL_ROOT_LEGAL_ENTITY_ID));
         this.serviceAgreementsConfigurator
             .setEntitlementsAdminUnderMsa(admin.getExternalId(), EXTERNAL_ROOT_LEGAL_ENTITY_ID);
@@ -63,8 +84,45 @@ public class LegalEntitiesAndUsersConfigurator {
 
         legalEntityWithUsers.getUsers().parallelStream()
             .forEach(
-                user -> this.userIntegrationRestClient
-                    .ingestUserAndLogResponse(LegalEntitiesAndUsersDataGenerator
-                        .generateUsersPostRequestBody(user, externalLegalEntityId)));
+                user -> this.ingestUserAndLogResponse(LegalEntitiesAndUsersDataGenerator
+                    .generateUsersPostRequestBody(user, externalLegalEntityId)));
+    }
+    
+
+    private void ingestUserAndLogResponse(UsersPostRequestBody user) {
+
+        com.backbase.dbs.user.presentation.rest.spec.v2.users.UsersPostRequestBody userBody = new com.backbase.dbs.user.presentation.rest.spec.v2.users.UsersPostRequestBody();
+
+        Response response;
+
+        if (this.globalProperties.getBoolean(PROPERTY_IDENTITY_FEATURE_TOGGLE)) {
+            response = this.userIntegrationRestClient.importUserIdentity(user);
+        } else {
+            response = this.userIntegrationRestClient.ingestUser(user);
+        }
+
+        if (isBadRequestException(response, "User already exists") || isConflictException(response, "User already exists")) {
+            log.info("User [{}] already exists, skipped ingesting this user", user.getExternalId());
+        } else if (isNotFoundException(response, "Identity does not exist in Identity Service")) {
+            log.info("Identity for user [{}] not found, creating identity", user.getExternalId());
+
+            String legalEntityId = legalEntityPresentationRestClient
+                .retrieveLegalEntityByExternalId(user.getLegalEntityExternalId()).getId();
+
+            userBody
+                .withExternalId(user.getExternalId())
+                .withFullName(user.getFullName())
+                .withLegalEntityExternalId(user.getLegalEntityExternalId())
+                .withPreferredLanguage(user.getPreferredLanguage());
+
+            this.userPresentationRestClient.createIdentityUserAndLogResponse(userBody, legalEntityId);
+        } else if (response.statusCode() == SC_CREATED) {
+            log.info("User [{}] ingested under legal entity [{}]",
+                user.getExternalId(), user.getLegalEntityExternalId());
+        } else {
+            log.info("User [{}] could not be ingested", user.getExternalId());
+            response.then()
+                .statusCode(SC_CREATED);
+        }
     }
 }

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/LegalEntitiesAndUsersConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/LegalEntitiesAndUsersConfigurator.java
@@ -91,8 +91,6 @@ public class LegalEntitiesAndUsersConfigurator {
 
     private void ingestUserAndLogResponse(UsersPostRequestBody user) {
 
-        com.backbase.dbs.user.presentation.rest.spec.v2.users.UsersPostRequestBody userBody = new com.backbase.dbs.user.presentation.rest.spec.v2.users.UsersPostRequestBody();
-
         Response response;
 
         if (this.globalProperties.getBoolean(PROPERTY_IDENTITY_FEATURE_TOGGLE)) {
@@ -108,6 +106,9 @@ public class LegalEntitiesAndUsersConfigurator {
 
             String legalEntityId = legalEntityPresentationRestClient
                 .retrieveLegalEntityByExternalId(user.getLegalEntityExternalId()).getId();
+
+            com.backbase.dbs.user.presentation.rest.spec.v2.users.UsersPostRequestBody userBody =
+                new com.backbase.dbs.user.presentation.rest.spec.v2.users.UsersPostRequestBody();
 
             userBody
                 .withExternalId(user.getExternalId())

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/LegalEntitiesAndUsersConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/LegalEntitiesAndUsersConfigurator.java
@@ -90,7 +90,7 @@ public class LegalEntitiesAndUsersConfigurator {
     
 
     private void ingestUserAndLogResponse(UsersPostRequestBody user) {
-
+        
         Response response;
 
         if (this.globalProperties.getBoolean(PROPERTY_IDENTITY_FEATURE_TOGGLE)) {
@@ -106,11 +106,10 @@ public class LegalEntitiesAndUsersConfigurator {
 
             String legalEntityId = legalEntityPresentationRestClient
                 .retrieveLegalEntityByExternalId(user.getLegalEntityExternalId()).getId();
-
-
+            
             com.backbase.dbs.user.presentation.rest.spec.v2.users.UsersPostRequestBody userBody =
                 new com.backbase.dbs.user.presentation.rest.spec.v2.users.UsersPostRequestBody();
-            
+
             userBody
                 .withExternalId(user.getExternalId())
                 .withFullName(user.getFullName())

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/LegalEntitiesAndUsersConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/LegalEntitiesAndUsersConfigurator.java
@@ -90,7 +90,7 @@ public class LegalEntitiesAndUsersConfigurator {
     
 
     private void ingestUserAndLogResponse(UsersPostRequestBody user) {
-        
+
         Response response;
 
         if (this.globalProperties.getBoolean(PROPERTY_IDENTITY_FEATURE_TOGGLE)) {

--- a/src/main/java/com/backbase/ct/bbfuel/util/ResponseUtils.java
+++ b/src/main/java/com/backbase/ct/bbfuel/util/ResponseUtils.java
@@ -1,8 +1,13 @@
 package com.backbase.ct.bbfuel.util;
 
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_CONFLICT;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+
 
 import com.backbase.buildingblocks.presentation.errors.BadRequestException;
+import com.backbase.buildingblocks.presentation.errors.NotFoundException;
+import com.backbase.presentation.user.rest.spec.v2.users.exceptions.ConflictException;
 import io.restassured.response.Response;
 
 public class ResponseUtils {
@@ -13,8 +18,34 @@ public class ResponseUtils {
             .as(BadRequestException.class);
     }
 
+    private static ConflictException asConflictException(Response response) {
+        return response.then()
+            .extract()
+            .as(ConflictException.class);
+    }
+
+    private static NotFoundException asNotFoundException(Response response) {
+        return response.then()
+            .extract()
+            .as(NotFoundException.class);
+    }
+
     private static String getBadRequestMessage(Response response) {
         return asBadRequestException(response)
+            .getErrors()
+            .get(0)
+            .getMessage();
+    }
+
+    private static String getConflictException(Response response) {
+        return asConflictException(response)
+            .getErrors()
+            .get(0)
+            .getMessage();
+    }
+
+    private static String getNotFoundException(Response response) {
+        return asNotFoundException(response)
             .getErrors()
             .get(0)
             .getMessage();
@@ -28,9 +59,34 @@ public class ResponseUtils {
         return response.statusCode() == SC_BAD_REQUEST && getBadRequestMessage(response).equals(withMessage);
     }
 
+    public static boolean isConflictException(Response response, String withMessage) {
+        return response.statusCode() == SC_CONFLICT && getConflictException(response).equals(withMessage);
+    }
+
+    public static boolean isNotFoundException(Response response, String withMessage){
+        return response.statusCode() == SC_NOT_FOUND && getNotFoundException(response).equals(withMessage);
+    }
+
     public static boolean isBadRequestExceptionWithErrorKey(Response response, String withErrorKey) {
         return response.statusCode() == SC_BAD_REQUEST
             && asBadRequestException(response)
+            .getErrors()
+            .get(0)
+            .getKey()
+            .equals(withErrorKey);
+    }
+
+    public static boolean isConflictExceptionWithErrorKey(Response response, String withErrorKey) {
+        return response.statusCode() == SC_CONFLICT
+            && asConflictException(response)
+            .getErrors()
+            .get(0)
+            .equals(withErrorKey);
+    }
+
+    public static boolean isNotFoundExceptionWithErrorKey(Response response, String withErrorKey) {
+        return response.statusCode() == SC_NOT_FOUND
+            && asNotFoundException(response)
             .getErrors()
             .get(0)
             .getKey()


### PR DESCRIPTION
Adding the ability to ingest users into both identity and DBS using bb-fuel for lean identity installations.
Currently BB-fuel ingests users for test purposes via the user integration service, creating them only in DBS. For Identity installations having the users present in both DBS and Identity is required.

When identity.feature.toggle is set to true the ingested user details are passed to the import user endpoint in the user integration service, if the given user does not exist in identity then the details will be passed to the create identities endpoint in the presentation service which will add the user to both DBS and Identity.

**Additional Information**

- The ingestUserAndLogResponse method was moved from the Integration rest client class to avoid having integration rest client and presentation rent client importing and relying on each other.

**Testing**

Testing involved ingesting via bb-fuel against a lean identity environment. The users widget correctly displayed an empty list of users before ingestion and the complete list after ingestion, along with the users in keycloak

This implementation was also tested against an environment without identity, in which the users were added to DBS as per the current implementation, to ensure current use cases should not be effected