### PR TITLE
Local data ingestion web app

### DIFF
--- a/src/main/resources/data/us-productized-dataset/local/legal-entities-with-users.json
+++ b/src/main/resources/data/us-productized-dataset/local/legal-entities-with-users.json
@@ -1,0 +1,23 @@
+[
+  {
+    "users": [
+      {
+        "externalId": "user"
+      }
+    ]
+  },
+  {
+    "users": [
+      {
+        "externalId": "designer"
+      }
+    ]
+  },
+  {
+    "users": [
+      {
+        "externalId": "manager"
+      }
+    ]
+  }
+]

--- a/src/main/resources/data/us-productized-dataset/us-productized-data.properties
+++ b/src/main/resources/data/us-productized-dataset/us-productized-data.properties
@@ -24,6 +24,8 @@ transactions.max=30
 # This is a comma (,) separated value
 transactions.currency=USD
 
+# Ingest account statements
+ingest.accountStatements=false 
 # Ingest approvals
 ingest.approvals.for.payments=false
 ingest.approvals.for.contacts=false


### PR DESCRIPTION
This PR adds the ability to ingest data locally for the US Web app test.

The data can be ingested running the following command:
```
java -jar -Dspring.profiles.active=local -Dingest.access.control=true -Dcustom.properties.path=data/us-productized-dataset/us-productized-data.properties -Dlegal.entities.with.users.json=data/us-productized-dataset/local/legal-entities-with-users.json -Didentity.feature.toggle=true bb-fuel-<VERSION>-boot.jar
```