### PR TITLE
- Downgrading access control spec to 2.5.0 because 2.6.0 is not on re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <url>https://repo.backbase.com/specs/access-control</url>
-                            <fromFile>access-control-client-api-v2.6.0.yaml</fromFile>
+                            <fromFile>access-control-client-api-v2.5.0.yaml</fromFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -400,7 +400,7 @@
                         <goal>generate</goal>
                     </goals>
                     <configuration>
-                        <inputSpec>${api.target}/access-control-client-api-v2.6.0.yaml</inputSpec>
+                        <inputSpec>${api.target}/access-control-client-api-v2.5.0.yaml</inputSpec>
                         <configOptions>
                             <apiPackage>com.backbase.dbs.accesscontrol.client.v2</apiPackage>
                             <modelPackage>com.backbase.dbs.accesscontrol.client.v2.model</modelPackage>


### PR DESCRIPTION
…po yet.