### PR TITLE
Using products open api

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ bb-fuel supports multiple DBS versions. See below which version maps to the requ
 
 | DBS version | bb-fuel minimal [version](https://github.com/backbase/bb-fuel/releases) |
 |-------------|-------------------------------------------------------------------------|
+| 2.21.1      | 2.6.66                                                                  |
 | 2.20.0      | 2.6.41                                                                  |
 | 2.19.0      | 2.6.31                                                                  |
 | 2.18.2      | 2.6.9                                                                   |

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 
         <api.target>${project.build.directory}/downloaded-api</api.target>
         <openapi-generator-version>5.1.0</openapi-generator-version>
+        <boat-maven-plugin.version>0.14.3</boat-maven-plugin.version>
         <jackson-databind.version>2.11.3</jackson-databind.version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <swagger-annotations-version>1.6.0</swagger-annotations-version>
@@ -50,10 +51,9 @@
         <common-types.version>1.0.5</common-types.version>
 
         <!-- Products Specs Versions -->
-
         <arrangement-integration-outbound-link-account-api.version>2.1.1</arrangement-integration-outbound-link-account-api.version>
         <arrangement-integration-outbound-origination-api.version>1.0.3</arrangement-integration-outbound-origination-api.version>
-        <arrangement-integration-inbound-api.version>2.2.0</arrangement-integration-inbound-api.version>
+        <arrangement-integration-inbound-api.version>2.4.1</arrangement-integration-inbound-api.version>
 
     </properties>
 
@@ -584,6 +584,31 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.backbase.oss</groupId>
+                <artifactId>boat-maven-plugin</artifactId>
+                <version>${boat-maven-plugin.version}</version>
+                <configuration>
+                    <output>${project.build.directory}/generated-sources/api</output>
+                    <generatorName>java</generatorName>
+                    <generateApiTests>false</generateApiTests>
+                    <generateModelTests>false</generateModelTests>
+                    <generateModelDocumentation>false</generateModelDocumentation>
+                    <generateApiDocumentation>false</generateApiDocumentation>
+
+                    <configOptions>
+                        <library>rest-assured</library>
+                        <dateLibrary>java8</dateLibrary>
+                        <serializationLibrary>jackson</serializationLibrary>
+                        <useSetForUniqueItems>true</useSetForUniqueItems>
+                        <useWithModifiers>true</useWithModifiers>
+                    </configOptions>
+                </configuration>
+
+                <executions>
 
                     <execution>
                         <id>generate-arrangement-outbound-origination-client-code</id>
@@ -661,14 +686,6 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>com.backbase.dbs.arrangement</groupId>
-                                    <artifactId>arrangement-integration-spec</artifactId>
-                                    <outputDirectory>
-                                        ${project.build.directory}/arrangement-integration-spec
-                                    </outputDirectory>
-                                </artifactItem>
-
-                                <artifactItem>
                                     <groupId>com.backbase.dbs.contact</groupId>
                                     <artifactId>contact-integration-external-inbound-spec</artifactId>
                                     <outputDirectory>
@@ -741,24 +758,6 @@
                             <inputFiles>
                                 <inputFile>
                                     ${project.build.directory}/approval-integration-spec/client-api.raml
-                                </inputFile>
-                            </inputFiles>
-                            <requestHeaders>false</requestHeaders>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>generate-arrangement-integration-spec</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>raml-api-generator</goal>
-                        </goals>
-                        <configuration>
-                            <serviceId>arrangement-service</serviceId>
-                            <packageName>dbs.arrangement.integration</packageName>
-                            <inputFiles>
-                                <inputFile>
-                                    ${project.build.directory}/arrangement-integration-spec/integration-api.raml
                                 </inputFile>
                             </inputFiles>
                             <requestHeaders>false</requestHeaders>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
 
         <service-sdk.version>11.0.0</service-sdk.version>
         <common-types.version>1.0.5</common-types.version>
+
+        <!-- Products Specs Versions -->
+
+        <arrangement-integration-outbound-link-account-api.version>2.1.1</arrangement-integration-outbound-link-account-api.version>
+        <arrangement-integration-outbound-origination-api.version>1.0.3</arrangement-integration-outbound-origination-api.version>
+        <arrangement-integration-inbound-api.version>2.2.0</arrangement-integration-inbound-api.version>
+
     </properties>
 
     <dependencyManagement>
@@ -388,18 +395,6 @@
                     </execution>
 
                     <execution>
-                        <id>download-arrangement-outbound-origination-api-spec</id>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <url>https://repo.backbase.com/specs/arrangement-manager</url>
-                            <fromFile>arrangement-integration-outbound-origination-api-v1.0.3.yaml</fromFile>
-                        </configuration>
-                    </execution>
-
-                    <execution>
                         <id>download-positive-pay-client-api</id>
                         <goals>
                             <goal>download-single</goal>
@@ -410,6 +405,32 @@
                             <fromFile>positive-pay-client-api-v1.0.0.yaml</fromFile>
                         </configuration>
                     </execution>
+
+                    <!-- Products Specs -->
+                    <execution>
+                        <id>download-arrangement-outbound-origination-api-spec</id>
+                        <goals>
+                            <goal>download-single</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <url>https://repo.backbase.com/specs/arrangement-manager</url>
+                            <fromFile>arrangement-integration-outbound-origination-api-v${arrangement-integration-outbound-origination-api.version}.yaml</fromFile>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>download-arrangement-integration-outbound-link-account-api-spec</id>
+                        <goals>
+                            <goal>download-single</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <url>https://repo.backbase.com/specs/arrangement-manager</url>
+                            <fromFile>arrangement-integration-outbound-link-account-api-v${arrangement-integration-outbound-link-account-api.version}.yaml</fromFile>
+                        </configuration>
+                    </execution>
+
                     <execution>
                         <id>download-arrangement-integration-inbound-api</id>
                         <goals>
@@ -418,7 +439,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <url>https://repo.backbase.com/specs/arrangement-manager</url>
-                            <fromFile>arrangement-integration-inbound-api-v2.2.0.yaml</fromFile>
+                            <fromFile>arrangement-integration-inbound-api-v${arrangement-integration-inbound-api.version}.yaml</fromFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -551,20 +572,6 @@
                     </execution>
 
                     <execution>
-                        <id>generate-arrangement-outbound-origination-client-code</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <inputSpec>${api.target}/arrangement-integration-outbound-origination-api-v1.0.3.yaml</inputSpec>
-                            <configOptions>
-                                <apiPackage>com.backbase.dbs.arrangement.integration.outbound.origination.v1</apiPackage>
-                                <modelPackage>com.backbase.dbs.arrangement.integration.outbound.origination.v1.model</modelPackage>
-                            </configOptions>
-                        </configuration>
-                    </execution>
-
-                    <execution>
                         <id>generate-positive-pay-client-code</id>
                         <goals>
                             <goal>generate</goal>
@@ -579,13 +586,41 @@
                     </execution>
 
                     <execution>
+                        <id>generate-arrangement-outbound-origination-client-code</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${api.target}/arrangement-integration-outbound-origination-api-v${arrangement-integration-outbound-origination-api.version}.yaml</inputSpec>
+                            <configOptions>
+                                <apiPackage>com.backbase.dbs.arrangement.integration.outbound.origination.v1</apiPackage>
+                                <modelPackage>com.backbase.dbs.arrangement.integration.outbound.origination.v1.model</modelPackage>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>generate-arrangement-integration-outbound-link-account-client-code</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${api.target}/arrangement-integration-outbound-link-account-api-v${arrangement-integration-outbound-link-account-api.version}.yaml</inputSpec>
+                            <configOptions>
+                                <apiPackage>com.backbase.dbs.arrangement.integration.outbound.link.v2</apiPackage>
+                                <modelPackage>com.backbase.dbs.arrangement.integration.outbound.link.v2.model</modelPackage>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+
+                    <execution>
                         <id>generate-arrangement-integration-inbound-api</id>
                         <goals>
                             <goal>generate</goal>
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <inputSpec>${api.target}/arrangement-integration-inbound-api-v2.2.0.yaml</inputSpec>
+                            <inputSpec>${api.target}/arrangement-integration-inbound-api-v${arrangement-integration-inbound-api.version}.yaml</inputSpec>
                             <configOptions>
                                 <apiPackage>com.backbase.dbs.arrangement.integration.inbound.api.v2</apiPackage>
                                 <modelPackage>com.backbase.dbs.arrangement.integration.inbound.api.v2.model</modelPackage>
@@ -608,13 +643,6 @@
                         <configuration>
                             <includes>**/*.raml,**/*.json,**/*.md,**/*.csv</includes>
                             <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.backbase.dbs.account</groupId>
-                                    <artifactId>account-integration-spec</artifactId>
-                                    <outputDirectory>
-                                        ${project.build.directory}/account-integration-spec
-                                    </outputDirectory>
-                                </artifactItem>
 
                                 <artifactItem>
                                     <groupId>com.backbase.dbs.actions</groupId>
@@ -700,23 +728,6 @@
                     <outputFile>target/generated-sources</outputFile>
                 </configuration>
                 <executions>
-                    <execution>
-                        <id>generate-account-integration-spec</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>raml-api-generator</goal>
-                        </goals>
-                        <configuration>
-                            <serviceId>account-integration-service</serviceId>
-                            <packageName>dbs.account</packageName>
-                            <inputFiles>
-                                <inputFile>
-                                    ${project.build.directory}/account-integration-spec/service-api.raml
-                                </inputFile>
-                            </inputFiles>
-                            <requestHeaders>false</requestHeaders>
-                        </configuration>
-                    </execution>
 
                     <execution>
                         <id>generate-approval-integration-spec</id>

--- a/src/main/java/com/backbase/ct/bbfuel/client/productsummary/AccountsIntegrationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/productsummary/AccountsIntegrationRestClient.java
@@ -4,7 +4,7 @@ import static org.apache.http.HttpStatus.SC_OK;
 
 import com.backbase.ct.bbfuel.client.common.RestClient;
 import com.backbase.ct.bbfuel.config.BbFuelConfiguration;
-import com.backbase.integration.account.spec.v2.arrangements.ArrangementItem;
+import com.backbase.dbs.arrangement.integration.outbound.link.v2.model.ArrangementItem;
 import groovy.util.logging.Slf4j;
 import io.restassured.http.ContentType;
 import java.util.Arrays;

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/BillPayConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/BillPayConfigurator.java
@@ -16,7 +16,7 @@ import com.backbase.dbs.billpay.client.v2.model.Subscriber;
 import com.backbase.dbs.billpay.client.v2.model.SubscriberAccount;
 import com.backbase.dbs.billpay.client.v2.model.SubscriberAddress;
 import com.backbase.dbs.billpay.client.v2.model.UserByIdPutRequestBody;
-import com.backbase.integration.account.spec.v2.arrangements.ArrangementItem;
+import com.backbase.dbs.arrangement.integration.outbound.link.v2.model.ArrangementItem;
 import io.restassured.response.Response;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/PocketsConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/PocketsConfigurator.java
@@ -8,15 +8,13 @@ import com.backbase.ct.bbfuel.data.ProductSummaryDataGenerator;
 import com.backbase.ct.bbfuel.input.PocketsReader;
 import com.backbase.ct.bbfuel.service.AccessGroupService;
 import com.backbase.dbs.accesscontrol.client.v2.model.LegalEntityBase;
-import com.backbase.dbs.arrangement.integration.rest.spec.v2.arrangements.ArrangementsPostResponseBody;
+import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.ArrangementAddedResponse;
+import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.PostArrangement;
 import com.backbase.dbs.pocket.tailor.client.v2.model.Pocket;
 import com.backbase.dbs.pocket.tailor.client.v2.model.PocketPostRequest;
-import com.backbase.integration.arrangement.rest.spec.v2.arrangements.ArrangementsPostRequestBody;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -42,7 +40,7 @@ public class PocketsConfigurator {
         log.debug("Going to ingest a parent pocket arrangement for external legal entity ID: [{}]", legalEntity);
 
         String parentPocketArrangementId = null;
-        ArrangementsPostResponseBody arrangementsPostResponseBody = ingestParentPocketArrangement(legalEntity);
+        ArrangementAddedResponse arrangementsPostResponseBody = ingestParentPocketArrangement(legalEntity);
 
         if (arrangementsPostResponseBody != null) {
             parentPocketArrangementId = arrangementsPostResponseBody.getId();
@@ -79,8 +77,8 @@ public class PocketsConfigurator {
         }
     }
 
-    private ArrangementsPostResponseBody ingestParentPocketArrangement(LegalEntityBase legalEntity) {
-        ArrangementsPostRequestBody parentPocketArrangement = ProductSummaryDataGenerator
+    private ArrangementAddedResponse ingestParentPocketArrangement(LegalEntityBase legalEntity) {
+        PostArrangement parentPocketArrangement = ProductSummaryDataGenerator
             .generateParentPocketArrangement(legalEntity.getExternalId());
         return arrangementsIntegrationRestClient
             .ingestParentPocketArrangementAndLogResponse(parentPocketArrangement);

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/PositivePayConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/PositivePayConfigurator.java
@@ -1,4 +1,12 @@
 package com.backbase.ct.bbfuel.configurator;
+
+import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_POSITIVEPAY_MAX;
+import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_POSITIVEPAY_MIN;
+import static com.backbase.ct.bbfuel.util.CommonHelpers.generateRandomNumberInRange;
+import static com.backbase.ct.bbfuel.util.CommonHelpers.getRandomFromList;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.apache.http.HttpStatus.SC_OK;
+
 import com.backbase.ct.bbfuel.client.accessgroup.UserContextPresentationRestClient;
 import com.backbase.ct.bbfuel.client.common.LoginRestClient;
 import com.backbase.ct.bbfuel.client.positivepay.PositivePayRestClient;
@@ -10,21 +18,12 @@ import com.backbase.ct.bbfuel.util.GlobalProperties;
 import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.Subscription;
 import com.backbase.dbs.positivepay.client.api.v1.model.PositivePayPost;
 import com.backbase.dbs.productsummary.presentation.rest.spec.v2.productsummary.ArrangementsByBusinessFunctionGetResponseBody;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
-
-import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_POSITIVEPAY_MIN;
-import static com.backbase.ct.bbfuel.data.CommonConstants.PROPERTY_POSITIVEPAY_MAX;
-import static com.backbase.ct.bbfuel.util.CommonHelpers.generateRandomNumberInRange;
-import static com.backbase.ct.bbfuel.util.CommonHelpers.getRandomFromList;
-import static com.google.common.collect.Lists.newArrayList;
-import static org.apache.http.HttpStatus.SC_OK;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -79,13 +78,13 @@ public class PositivePayConfigurator {
         // Assigning a check subscription
         String randomSubscription = getRandomFromList(CHECK_SUBSCRIPTIONS);
         arrangementsIntegrationRestClient.postSubscriptions(arrangementId.getExternalArrangementId(),
-            new Subscription().identifier(randomSubscription));
+            new Subscription().withIdentifier(randomSubscription));
         log.info("Positive Pay check subscription : [{}] submitted for arrangement id [{}]",
             randomSubscription, arrangementId.getInternalArrangementId());
 
         // Assigning an ACH subscription
         arrangementsIntegrationRestClient.postSubscriptions(arrangementId.getExternalArrangementId(),
-            new Subscription().identifier(SUBSCRIPTION_ACH_POSITIVE_PAY));
+            new Subscription().withIdentifier(SUBSCRIPTION_ACH_POSITIVE_PAY));
         log.info("Positive Pay ACH subscription submitted for arrangement id [{}]",
             arrangementId.getInternalArrangementId());
     }

--- a/src/main/java/com/backbase/ct/bbfuel/data/ProductSummaryDataGenerator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/ProductSummaryDataGenerator.java
@@ -230,7 +230,7 @@ public class ProductSummaryDataGenerator {
             .withCountrySubDivision(faker.address().state())
             .withBIC(bic)
             .withStateId(getRandomFromList(ARRANGEMENT_STATES))
-            .withCardDetails(generateCardDetails())
+            .withCardDetails("4".equals(productId) ? generateCardDetails() : null)
             .withInterestDetails(generateInterestDetails())
             .withReservedAmount(generateRandomAmountInRange(500L, 10000L))
             .withRemainingPeriodicTransfers(generateRandomAmountInRange(500L, 10000L))

--- a/src/main/java/com/backbase/ct/bbfuel/data/ProductSummaryDataGenerator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/ProductSummaryDataGenerator.java
@@ -1,6 +1,9 @@
 package com.backbase.ct.bbfuel.data;
 
 import static com.backbase.ct.bbfuel.util.CommonHelpers.generateRandomAmountInRange;
+import static com.backbase.ct.bbfuel.util.CommonHelpers.generateRandomBranchCode;
+import static com.backbase.ct.bbfuel.util.CommonHelpers.generateRandomCardProvider;
+import static com.backbase.ct.bbfuel.util.CommonHelpers.generateRandomDateInRange;
 import static com.backbase.ct.bbfuel.util.CommonHelpers.generateRandomNumberInRange;
 import static com.backbase.ct.bbfuel.util.CommonHelpers.getRandomFromList;
 import static java.lang.String.valueOf;
@@ -12,13 +15,16 @@ import com.backbase.ct.bbfuel.dto.entitlement.ProductGroupSeed;
 import com.backbase.ct.bbfuel.input.ProductReader;
 import com.backbase.ct.bbfuel.util.GlobalProperties;
 import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.BalanceHistoryItem;
+import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.CardDetails;
 import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.IntegrationDebitCardItem;
+import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.InterestDetails;
 import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.PostArrangement;
 import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.ProductItem;
 import com.github.javafaker.Faker;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -223,7 +229,15 @@ public class ProductSummaryDataGenerator {
             .withAccountHolderCountry(faker.address().countryCode())
             .withCountrySubDivision(faker.address().state())
             .withBIC(bic)
-            .withStateId(getRandomFromList(ARRANGEMENT_STATES));
+            .withStateId(getRandomFromList(ARRANGEMENT_STATES))
+            .withCardDetails(generateCardDetails())
+            .withInterestDetails(generateInterestDetails())
+            .withReservedAmount(generateRandomAmountInRange(500L, 10000L))
+            .withRemainingPeriodicTransfers(generateRandomAmountInRange(500L, 10000L))
+            .withNextClosingDate(generateRandomDateInRange(LocalDate.now().minusDays(30), LocalDate.now().minusDays(1)))
+            .withOverdueSince(generateRandomDateInRange(LocalDate.now().minusDays(30), LocalDate.now().minusDays(1)))
+            .withBankBranchCode(generateRandomBranchCode())
+            .withBankBranchCode2(generateRandomBranchCode());
 
         if (EUR.equals(currency)) {
             arrangementsPostRequestBody
@@ -234,6 +248,32 @@ public class ProductSummaryDataGenerator {
                 .withBBAN(accountNumber);
         }
         return arrangementsPostRequestBody;
+    }
+
+    public static CardDetails generateCardDetails() {
+        return (CardDetails) new CardDetails()
+            .withAvailableCashCredit(generateRandomAmountInRange(500L, 10000L))
+            .withCardProvider(generateRandomCardProvider())
+            .withCashCreditLimit(generateRandomAmountInRange(1500L, 15000L))
+            .withLastPaymentAmount(generateRandomAmountInRange(1L, 1000L))
+            .withLastPaymentDate(generateRandomDateInRange(LocalDate.now().minusDays(30), LocalDate.now()))
+            .withLatePaymentFee(generateRandomNumberInRange(1, 2) == 1 ? generateRandomNumberInRange(1, 10) + "%"
+                : String.valueOf(generateRandomNumberInRange(1, 50)))
+            .withPreviousStatementBalance(generateRandomAmountInRange(500L, 2000L))
+            .withPreviousStatementDate(
+                generateRandomDateInRange(LocalDate.now().minusDays(60), LocalDate.now().minusDays(30)))
+            .withSecured(generateRandomNumberInRange(1, 2) == 1)
+            .withStatementBalance(generateRandomAmountInRange(500L, 2000L));
+    }
+
+    public static InterestDetails generateInterestDetails() {
+        return (InterestDetails) new InterestDetails()
+            .withAnnualPercentageYield(generateRandomAmountInRange(1L, 8L))
+            .withCashAdvanceInterestRate(generateRandomAmountInRange(1L, 10L))
+            .withDividendWithheldYTD(generateRandomNumberInRange(1, 2) == 1 ? generateRandomNumberInRange(1, 10) + "%"
+                : String.valueOf(generateRandomNumberInRange(1, 50)))
+            .withLastYearAccruedInterest(generateRandomAmountInRange(50L, 150L))
+            .withPenaltyInterestRate(generateRandomAmountInRange(1L, 10L));
     }
 
     public static List<BalanceHistoryItem> generateBalanceHistoryPostRequestBodies(

--- a/src/main/java/com/backbase/ct/bbfuel/input/ProductReader.java
+++ b/src/main/java/com/backbase/ct/bbfuel/input/ProductReader.java
@@ -6,7 +6,7 @@ import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 
 import com.backbase.ct.bbfuel.util.ParserUtil;
-import com.backbase.dbs.arrangement.integration.rest.spec.v2.products.ProductsPostRequestBody;
+import com.backbase.dbs.arrangement.integration.inbound.api.v2.model.ProductItem;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -26,18 +26,18 @@ public class ProductReader extends BaseReader {
     /**
      * Load the configured json file.
      */
-    public List<ProductsPostRequestBody> load() {
+    public List<ProductItem> load() {
         return load(this.globalProperties.getString(PROPERTY_PRODUCTS_JSON_LOCATION));
     }
 
     /**
      * Load json file.
      */
-    public List<ProductsPostRequestBody> load(String uri) {
-        List<ProductsPostRequestBody> products;
+    public List<ProductItem> load(String uri) {
+        List<ProductItem> products;
         try {
-            ProductsPostRequestBody[] parsedProducts = ParserUtil.convertJsonToObject(
-                uri, ProductsPostRequestBody[].class);
+            ProductItem[] parsedProducts = ParserUtil.convertJsonToObject(
+                uri, ProductItem[].class);
             validate(parsedProducts);
             products = asList(parsedProducts);
         } catch (IOException e) {
@@ -50,12 +50,12 @@ public class ProductReader extends BaseReader {
     /**
      * Check on duplicate ids.
      */
-    private void validate(ProductsPostRequestBody[] products) {
+    private void validate(ProductItem[] products) {
         if (ArrayUtils.isEmpty(products)) {
             throw new InvalidInputException("No products have been parsed");
         }
         List<String> ids = stream(products)
-            .map(ProductsPostRequestBody::getId)
+            .map(ProductItem::getId)
             .collect(toList());
         Set<String> uniqueIds = new HashSet<>(ids);
         if (uniqueIds.size() != products.length) {

--- a/src/main/java/com/backbase/ct/bbfuel/util/CommonHelpers.java
+++ b/src/main/java/com/backbase/ct/bbfuel/util/CommonHelpers.java
@@ -1,13 +1,24 @@
 package com.backbase.ct.bbfuel.util;
 
+import static java.util.Arrays.asList;
+
+import com.github.javafaker.CreditCardType;
+import com.github.javafaker.Faker;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang.StringUtils;
 
-public class CommonHelpers {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CommonHelpers {
+
+    private static final List<String> VALID_BRANCH_CODES = asList(
+        "122105155", "082000549", "121122676", "091300023", "121201694", "123123123", "307070115", "091000022"
+    );
 
     public static int generateRandomNumberInRange(int min, int max) {
         if (min > max) {
@@ -22,8 +33,11 @@ public class CommonHelpers {
         return new BigDecimal("" + ((value / 10D) + min)).setScale(2, BigDecimal.ROUND_HALF_UP);
     }
 
-    public static LocalDate generateRandomDateInRange(LocalDate min , LocalDate max)
-    {
+    public static String generateRandomBranchCode() {
+        return VALID_BRANCH_CODES.get(generateRandomNumberInRange(0, VALID_BRANCH_CODES.size() - 1));
+    }
+
+    public static LocalDate generateRandomDateInRange(LocalDate min, LocalDate max) {
         long days = min.until(max, ChronoUnit.DAYS);
         long randomDays = ThreadLocalRandom.current().nextLong(days + 1);
         return min.plusDays(randomDays);
@@ -50,5 +64,10 @@ public class CommonHelpers {
 
     public static <T extends Enum> T getRandomFromEnumValues(T[] values) {
         return values[ThreadLocalRandom.current().nextInt(values.length)];
+    }
+
+    public static String generateRandomCardProvider() {
+        return CreditCardType.values()[new Faker().random().nextInt(CreditCardType.values().length)]
+            .name().replace("_", " ");
     }
 }


### PR DESCRIPTION
Use OpenAPI spec for arrangement-integration-outbound-link-account-api. Organize pom for products specs. 
Using boat to generate products models (they were not correctly generated using openapi generator maven plugin)
Add interestDetails, cardDetails and more to arrangement generator

@DariaUliankina bankBranchCodes was also added

Tested in k8s.