### PR TITLE
CME-1709 implement multifiles properties configuration

### DIFF
--- a/src/main/java/com/backbase/ct/bbfuel/data/ProductSummaryDataGenerator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/ProductSummaryDataGenerator.java
@@ -74,9 +74,9 @@ public class ProductSummaryDataGenerator {
         Splitter.on(',').trimResults().split(currentAccountArrangementIds)
             .forEach(staticCurrentAccountArrangementsQueue::add);
 
-        String[] notCurrentAccountArrangementIds = GlobalProperties.getInstance()
-            .getStringArray(CommonConstants.PROPERTY_ARRANGEMENT_NOT_CURRENT_ACCOUNT_EXTERNAL_IDS);
-        staticNotCurrentAccountArrangementsQueue.addAll(asList(notCurrentAccountArrangementIds));
+        List<String> notCurrentAccountArrangementIds = GlobalProperties.getInstance()
+            .getList(CommonConstants.PROPERTY_ARRANGEMENT_NOT_CURRENT_ACCOUNT_EXTERNAL_IDS);
+        staticNotCurrentAccountArrangementsQueue.addAll(notCurrentAccountArrangementIds);
     }
 
     static String generateRandomIban() {

--- a/src/main/java/com/backbase/ct/bbfuel/setup/CapabilitiesDataSetup.java
+++ b/src/main/java/com/backbase/ct/bbfuel/setup/CapabilitiesDataSetup.java
@@ -270,10 +270,8 @@ public class CapabilitiesDataSetup extends BaseSetup {
 
     private void ingestAccountStatementForSelectedUser() {
         if (this.globalProperties.getBoolean(PROPERTY_INGEST_ACCOUNT_STATEMENTS)) {
-            String externalUserIds = this.globalProperties.getString(PROPERTY_ACCOUNTSTATEMENTS_USERS);
-            Splitter.on(';').trimResults().split(externalUserIds).forEach(externalUserId -> {
-                this.accountStatementsConfigurator.ingestAccountStatements(externalUserId);
-            });
+            List<String> externalUserIds = this.globalProperties.getList(PROPERTY_ACCOUNTSTATEMENTS_USERS, true);
+            externalUserIds.forEach(this.accountStatementsConfigurator::ingestAccountStatements);
          }
      }
 

--- a/src/main/resources/data.properties
+++ b/src/main/resources/data.properties
@@ -64,7 +64,9 @@ pocket.mapping.mode=ONE_TO_MANY
 ingest.accountStatements=false
 accountStatement.min=25
 accountStatement.max=45
-accountStatement.externalUserIds=robin_green;user;manager;designer
+# External user ids whom account statements will be ingested
+# This is a comma (,) separated value, and it is merged from multiple configurations
+accountStatement.externalUserIds=robin_green,user,manager,designer
 # Number of checks for positivepay
 ingest.positivePay=false
 positivePay.min=25

--- a/src/main/resources/data/loans/loans.properties
+++ b/src/main/resources/data/loans/loans.properties
@@ -8,3 +8,7 @@ arrangement.not.currentaccount.externalIds=2070cd68-6550-4883-8a93-2599584c03e3,
   372ee927-f7ea-401b-8e90-1eba6842f055,ac7f98da-f8f6-429b-83d7-a7d28e2fa9ee,16d107c9-7ee9-4fac-b226-3a5e53bca10d
 arrangement.not.currentaccount.legal.entity.externalId.limit=loan_legal_entity
 arrangement.not.currentaccount.productId.limit=5
+
+# External user ids whom account statements will be ingested
+# This is a comma (,) separated value, and it is merged from multiple configurations
+accountStatement.externalUserIds=steve_johnson

--- a/src/main/resources/data/retail/data.properties
+++ b/src/main/resources/data/retail/data.properties
@@ -83,7 +83,9 @@ positivePay.max=35
 ingest.accountStatements=false
 accountStatement.min=25
 accountStatement.max=45
-accountStatement.externalUserIds=robin_green;user;manager;designer
+# External user ids whom account statements will be ingested
+# This is a comma (,) separated value, and it is merged from multiple configurations
+accountStatement.externalUserIds=robin_green,user,manager,designer
 
 # Multi tenancy configuration
 multi.tenancy.environment=false

--- a/src/test/java/com/backbase/ct/bbfuel/util/GlobalPropertiesTest.java
+++ b/src/test/java/com/backbase/ct/bbfuel/util/GlobalPropertiesTest.java
@@ -1,0 +1,67 @@
+package com.backbase.ct.bbfuel.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.junit.Test;
+
+public class GlobalPropertiesTest {
+
+    @Test
+    public void testGetList() {
+        // given
+        GlobalProperties properties = GlobalProperties.getInstance();
+
+        // when
+        List<String> actual = properties.getList("list.property");
+
+        // then
+        assertEquals(3, actual.size());
+        assertThat(actual,
+            containsInRelativeOrder("value1", "value2", "value3"));
+    }
+
+    @Test
+    public void testGetList_SingleValue() {
+        // given
+        GlobalProperties properties = GlobalProperties.getInstance();
+
+        // when
+        List<String> actual = properties.getList("single.property");
+
+        // then
+        assertEquals(1, actual.size());
+        assertEquals("value1", actual.get(0));
+    }
+
+    @Test
+    public void testGetList_allPropertiesCombined() {
+        // given
+        GlobalProperties properties = GlobalProperties.getInstance();
+
+        // when
+        List<String> actual = properties.getList("list.property", true);
+
+        // then
+        assertEquals(6, actual.size());
+        assertThat(actual,
+            containsInRelativeOrder("value1", "value2", "value3", "value4", "value5", "value6"));
+    }
+
+    @Test
+    public void testGetList_SingleValue_allPropertiesCombined() {
+        // given
+        GlobalProperties properties = GlobalProperties.getInstance();
+
+        // when
+        List<String> actual = properties.getList("single.property", true);
+
+        // then
+        assertEquals(2, actual.size());
+        assertEquals("value1", actual.get(0));
+
+        assertThat(actual, containsInRelativeOrder("value1", "value2"));
+    }
+}

--- a/src/test/resources/data.properties
+++ b/src/test/resources/data.properties
@@ -1,0 +1,3 @@
+list.property=value1,value2,value3
+
+single.property=value1

--- a/src/test/resources/environment.properties
+++ b/src/test/resources/environment.properties
@@ -1,0 +1,3 @@
+list.property=value4,value5,value6
+
+single.property=value2


### PR DESCRIPTION
Created a possibility to get merged from all properties (base, additional, system, environment, etc) list of string properties.

Fixed GlobalProperties#getList() method which affected PaymentsConfigurator. Now payment orders of different types will be created. 