### PR TITLE
Ingest contacts with account type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <arrangement-integration-outbound-origination-api.version>1.0.3</arrangement-integration-outbound-origination-api.version>
         <arrangement-integration-inbound-api.version>2.6.0</arrangement-integration-inbound-api.version>
         <contentservices-client-api.version>2.6.0</contentservices-client-api.version>
+        <contact-manager-integration-inbound-api.version>2.9.5</contact-manager-integration-inbound-api.version>
 
     </properties>
 
@@ -127,11 +128,6 @@
         <dependency>
             <groupId>com.backbase.dbs.arrangement</groupId>
             <artifactId>arrangement-integration-spec</artifactId>
-        </dependency>
-        <!-- Contact Manager -->
-        <dependency>
-            <groupId>com.backbase.dbs.contact</groupId>
-            <artifactId>contact-integration-external-inbound-spec</artifactId>
         </dependency>
         <!-- Limits -->
         <dependency>
@@ -464,6 +460,18 @@
                             <fromFile>contentservices-client-api-v${contentservices-client-api.version}.yaml</fromFile>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>download-contact-manager-integration-inbound-api-spec</id>
+                        <goals>
+                            <goal>download-single</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <url>https://repo.backbase.com/specs/contact-manager</url>
+                            <fromFile>contact-manager-integration-inbound-api-v${contact-manager-integration-inbound-api.version}.yaml</fromFile>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -620,6 +628,20 @@
                             </configOptions>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>generate-contact-manager-integration-inbound-api-client-code</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${api.target}/contact-manager-integration-inbound-api-v${contact-manager-integration-inbound-api.version}.yaml</inputSpec>
+                            <configOptions>
+                                <apiPackage>com.backbase.dbs.contact.integration.inbound.api.v2</apiPackage>
+                                <modelPackage>com.backbase.dbs.contact.integration.inbound.api.v2.model</modelPackage>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -722,14 +744,6 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>com.backbase.dbs.contact</groupId>
-                                    <artifactId>contact-integration-external-inbound-spec</artifactId>
-                                    <outputDirectory>
-                                        ${project.build.directory}/contact-integration-external-inbound-spec
-                                    </outputDirectory>
-                                </artifactItem>
-
-                                <artifactItem>
                                     <groupId>com.backbase.dbs.messages</groupId>
                                     <artifactId>messages-service-spec</artifactId>
                                     <outputDirectory>
@@ -794,24 +808,6 @@
                             <inputFiles>
                                 <inputFile>
                                     ${project.build.directory}/approval-integration-spec/client-api.raml
-                                </inputFile>
-                            </inputFiles>
-                            <requestHeaders>false</requestHeaders>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>generate-contact-manager-integration-external-inbound-spec</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>raml-api-generator</goal>
-                        </goals>
-                        <configuration>
-                            <serviceId>contact-manager-service</serviceId>
-                            <packageName>dbs.productsummary.presentation</packageName>
-                            <inputFiles>
-                                <inputFile>
-                                    ${project.build.directory}/contact-integration-external-inbound-spec/integration-api.raml
                                 </inputFile>
                             </inputFiles>
                             <requestHeaders>false</requestHeaders>

--- a/src/main/java/com/backbase/ct/bbfuel/client/contact/ContactIntegrationRestClient.java
+++ b/src/main/java/com/backbase/ct/bbfuel/client/contact/ContactIntegrationRestClient.java
@@ -2,7 +2,7 @@ package com.backbase.ct.bbfuel.client.contact;
 
 import com.backbase.ct.bbfuel.client.common.RestClient;
 import com.backbase.ct.bbfuel.config.BbFuelConfiguration;
-import com.backbase.dbs.productsummary.presentation.rest.spec.v2.contacts.ContactsBulkIngestionPostRequestBody;
+import com.backbase.dbs.contact.integration.inbound.api.v2.model.ContactsBulkPostRequestBody;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import javax.annotation.PostConstruct;
@@ -24,7 +24,7 @@ public class ContactIntegrationRestClient extends RestClient {
         setVersion(SERVICE_VERSION);
     }
 
-    public Response ingestContacts(ContactsBulkIngestionPostRequestBody body) {
+    public Response ingestContacts(ContactsBulkPostRequestBody body) {
         return requestSpec()
             .contentType(ContentType.JSON)
             .body(body)

--- a/src/main/java/com/backbase/ct/bbfuel/configurator/ContactsConfigurator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/configurator/ContactsConfigurator.java
@@ -10,7 +10,7 @@ import static org.apache.http.HttpStatus.SC_CREATED;
 
 import com.backbase.ct.bbfuel.client.contact.ContactIntegrationRestClient;
 import com.backbase.ct.bbfuel.util.GlobalProperties;
-import com.backbase.dbs.productsummary.presentation.rest.spec.v2.contacts.ContactsBulkIngestionPostRequestBody;
+import com.backbase.dbs.contact.integration.inbound.api.v2.model.ContactsBulkPostRequestBody;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,7 +30,7 @@ public class ContactsConfigurator {
             globalProperties.getInt(PROPERTY_CONTACT_ACCOUNTS_MIN),
             globalProperties.getInt(PROPERTY_CONTACT_ACCOUNTS_MAX));
 
-        ContactsBulkIngestionPostRequestBody contactsBulkIngestionPostRequestBody = generateContactsBulkIngestionPostRequestBody(
+        ContactsBulkPostRequestBody contactsBulkIngestionPostRequestBody = generateContactsBulkIngestionPostRequestBody(
             externalServiceAgreementId, externalUserId, numberOfContacts, numberOfAccountsPerContact);
 
         contactIntegrationRestClient.ingestContacts(contactsBulkIngestionPostRequestBody)

--- a/src/main/java/com/backbase/ct/bbfuel/data/ContactsDataGenerator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/ContactsDataGenerator.java
@@ -28,7 +28,7 @@ public class ContactsDataGenerator {
     private static final GlobalProperties globalProperties = GlobalProperties.getInstance();
     private static final Faker faker = new Faker();
     private static final List<String> VALID_BIC_LIST = asList("ABNANL2A", "ANDLNL2A", "ARBNNL22", "ARSNNL21");
-    private static final List<String> VALID_ACCOUNT_TYPE = asList("CHECKING", "SAVINGS");
+    private static final List<String> VALID_ACCOUNT_TYPE = asList("Checking", "Savings");
 
     public static ContactsBulkPostRequestBody generateContactsBulkIngestionPostRequestBody(
         String externalServiceAgreementId, String externalUserId, int numberOfContacts,

--- a/src/main/java/com/backbase/ct/bbfuel/data/ContactsDataGenerator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/ContactsDataGenerator.java
@@ -28,7 +28,7 @@ public class ContactsDataGenerator {
     private static final GlobalProperties globalProperties = GlobalProperties.getInstance();
     private static final Faker faker = new Faker();
     private static final List<String> VALID_BIC_LIST = asList("ABNANL2A", "ANDLNL2A", "ARBNNL22", "ARSNNL21");
-    private static final List<String> VALID_ACCOUNT_TYPE = asList("Checking", "Savings");
+    private static final List<String> VALID_ACCOUNT_TYPE_LIST = asList("Checking", "Savings");
 
     public static ContactsBulkPostRequestBody generateContactsBulkIngestionPostRequestBody(
         String externalServiceAgreementId, String externalUserId, int numberOfContacts,
@@ -64,7 +64,7 @@ public class ContactsDataGenerator {
                     .town(faker.address().cityName())
                     .country(faker.address().countryCode())
                     .countrySubDivision(faker.address().state()))
-                .accountType(VALID_ACCOUNT_TYPE.get(faker.random().nextInt(VALID_ACCOUNT_TYPE.size())))
+                .accountType(VALID_ACCOUNT_TYPE_LIST.get(faker.random().nextInt(VALID_ACCOUNT_TYPE_LIST.size())))
                 .bankCode(createRandomValidRtn())
                 .bankAddress(new Address()
                     .addressLine1(faker.address().streetAddress())

--- a/src/main/java/com/backbase/ct/bbfuel/data/ContactsDataGenerator.java
+++ b/src/main/java/com/backbase/ct/bbfuel/data/ContactsDataGenerator.java
@@ -7,15 +7,15 @@ import static java.util.Arrays.asList;
 
 import com.backbase.ct.bbfuel.util.CommonHelpers;
 import com.backbase.ct.bbfuel.util.GlobalProperties;
-import com.backbase.dbs.integration.external.inbound.contact.rest.spec.v2.contacts.ExternalAccountInformation;
-import com.backbase.dbs.integration.external.inbound.contact.rest.spec.v2.contacts.ExternalContact;
-import com.backbase.dbs.productsummary.presentation.rest.spec.v2.contacts.AccessContext;
-import com.backbase.dbs.productsummary.presentation.rest.spec.v2.contacts.Address;
-import com.backbase.dbs.productsummary.presentation.rest.spec.v2.contacts.ContactsBulkIngestionPostRequestBody;
+import com.backbase.dbs.contact.integration.inbound.api.v2.model.AccessContext;
+import com.backbase.dbs.contact.integration.inbound.api.v2.model.AccessContextScope;
+import com.backbase.dbs.contact.integration.inbound.api.v2.model.Address;
+import com.backbase.dbs.contact.integration.inbound.api.v2.model.ContactsBulkPostRequestBody;
+import com.backbase.dbs.contact.integration.inbound.api.v2.model.ExternalAccountInformation;
+import com.backbase.dbs.contact.integration.inbound.api.v2.model.ExternalContact;
 import com.github.javafaker.Faker;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -28,17 +28,18 @@ public class ContactsDataGenerator {
     private static final GlobalProperties globalProperties = GlobalProperties.getInstance();
     private static final Faker faker = new Faker();
     private static final List<String> VALID_BIC_LIST = asList("ABNANL2A", "ANDLNL2A", "ARBNNL22", "ARSNNL21");
+    private static final List<String> VALID_ACCOUNT_TYPE = asList("CHECKING", "SAVINGS");
 
-    public static ContactsBulkIngestionPostRequestBody generateContactsBulkIngestionPostRequestBody(
+    public static ContactsBulkPostRequestBody generateContactsBulkIngestionPostRequestBody(
         String externalServiceAgreementId, String externalUserId, int numberOfContacts,
         int numberOfAccountsPerContact) {
-        return new ContactsBulkIngestionPostRequestBody()
-            .withAccessContext(new AccessContext()
-                .withExternalServiceAgreementId(externalServiceAgreementId)
-                .withExternalLegalEntityId(null)
-                .withExternalUserId(externalUserId)
-                .withScope(AccessContext.Scope.SA))
-            .withContacts(generateContacts(numberOfContacts, numberOfAccountsPerContact));
+        return new ContactsBulkPostRequestBody()
+            .accessContext(new AccessContext()
+                .externalServiceAgreementId(externalServiceAgreementId)
+                .externalLegalEntityId(null)
+                .externalUserId(externalUserId)
+                .scope(AccessContextScope.SA))
+            .contacts(generateContacts(numberOfContacts, numberOfAccountsPerContact));
     }
 
     private static List<ExternalContact> generateContacts(int numberOfContacts, int numberOfAccountsPerContact) {
@@ -51,27 +52,28 @@ public class ContactsDataGenerator {
 
         for (int i = 0; i < numberOfAccounts; i++) {
             ExternalAccountInformation externalAccountInformation = new ExternalAccountInformation()
-                .withExternalId(UUID.randomUUID().toString().substring(0, 32))
-                .withName(faker.lorem().sentence(3, 0).replace(".", ""))
-                .withAlias(faker.lorem().characters(10))
-                .withBic(VALID_BIC_LIST.get(new Random().nextInt(VALID_BIC_LIST.size())))
-                .withAccountHolderAddress(new Address()
-                    .withAddressLine1(faker.address().streetAddress())
-                    .withAddressLine2(faker.address().secondaryAddress())
-                    .withStreetName(faker.address().streetAddress())
-                    .withPostCode(faker.address().zipCode())
-                    .withTown(faker.address().cityName())
-                    .withCountry(faker.address().countryCode())
-                    .withCountrySubDivision(faker.address().state()))
-                .withBankCode(createRandomValidRtn())
-                .withBankAddress(new Address()
-                    .withAddressLine1(faker.address().streetAddress())
-                    .withAddressLine2(faker.address().secondaryAddress())
-                    .withStreetName(faker.address().streetAddress())
-                    .withPostCode(faker.address().zipCode())
-                    .withTown(faker.address().city())
-                    .withCountry(faker.address().countryCode())
-                    .withCountrySubDivision(faker.address().state()));
+                .externalId(UUID.randomUUID().toString().substring(0, 32))
+                .name(faker.lorem().sentence(3, 0).replace(".", ""))
+                .alias(faker.lorem().characters(10))
+                .bic(VALID_BIC_LIST.get(faker.random().nextInt(VALID_BIC_LIST.size())))
+                .accountHolderAddress(new Address()
+                    .addressLine1(faker.address().streetAddress())
+                    .addressLine2(faker.address().secondaryAddress())
+                    .streetName(faker.address().streetAddress())
+                    .postCode(faker.address().zipCode())
+                    .town(faker.address().cityName())
+                    .country(faker.address().countryCode())
+                    .countrySubDivision(faker.address().state()))
+                .accountType(VALID_ACCOUNT_TYPE.get(faker.random().nextInt(VALID_ACCOUNT_TYPE.size())))
+                .bankCode(createRandomValidRtn())
+                .bankAddress(new Address()
+                    .addressLine1(faker.address().streetAddress())
+                    .addressLine2(faker.address().secondaryAddress())
+                    .streetName(faker.address().streetAddress())
+                    .postCode(faker.address().zipCode())
+                    .town(faker.address().city())
+                    .country(faker.address().countryCode())
+                    .countrySubDivision(faker.address().state()));
 
             externalAccountInformation = determineTheUseOfIBANorBBAN(externalAccountInformation);
 
@@ -79,22 +81,22 @@ public class ContactsDataGenerator {
         }
 
         return new ExternalContact()
-            .withExternalId(UUID.randomUUID().toString().substring(0, 32))
-            .withName(faker.name().fullName())
-            .withAlias(faker.lorem().characters(10))
-            .withContactPerson(faker.name().fullName())
-            .withEmailId(faker.internet().emailAddress())
-            .withPhoneNumber(faker.phoneNumber().phoneNumber())
-            .withCategory(faker.lorem().characters(10))
-            .withAddress(new Address()
-                .withAddressLine1(faker.address().streetAddress())
-                .withAddressLine2(faker.address().secondaryAddress())
-                .withStreetName(faker.address().streetAddress())
-                .withPostCode(faker.address().zipCode())
-                .withTown(faker.address().city())
-                .withCountry(faker.address().countryCode())
-                .withCountrySubDivision(faker.address().state()))
-            .withAccounts(accounts);
+            .externalId(UUID.randomUUID().toString().substring(0, 32))
+            .name(faker.name().fullName())
+            .alias(faker.lorem().characters(10))
+            .contactPerson(faker.name().fullName())
+            .emailId(faker.internet().emailAddress())
+            .phoneNumber(faker.phoneNumber().phoneNumber())
+            .category(faker.lorem().characters(10))
+            .address(new Address()
+                .addressLine1(faker.address().streetAddress())
+                .addressLine2(faker.address().secondaryAddress())
+                .streetName(faker.address().streetAddress())
+                .postCode(faker.address().zipCode())
+                .town(faker.address().city())
+                .country(faker.address().countryCode())
+                .countrySubDivision(faker.address().state()))
+            .accounts(accounts);
     }
 
     private static ExternalAccountInformation determineTheUseOfIBANorBBAN(
@@ -106,12 +108,12 @@ public class ContactsDataGenerator {
 
         switch (availableAccountType.toUpperCase()) {
             case IBAN:
-                returnedExternalAccountInformation = externalAccountInformation.withIban(generateRandomIban());
+                returnedExternalAccountInformation = externalAccountInformation.iban(generateRandomIban());
                 break;
 
             case BBAN:
                 int randomBbanAccount = CommonHelpers.generateRandomNumberInRange(100000, 999999999);
-                returnedExternalAccountInformation = externalAccountInformation.withAccountNumber(
+                returnedExternalAccountInformation = externalAccountInformation.accountNumber(
                     String.valueOf(randomBbanAccount));
                 break;
 


### PR DESCRIPTION
The ingestion was tested on a beck environment. ACH Credit batches UI for choosing counterparty is working without extra modifications.


`contact-manager` database status after ingestion:

```
select count(*) from account_information ai;

count(*)|
--------+
    1803|

select account_type, count(account_type) from account_information ai group by account_type;

account_type|count(account_type)|
------------+-------------------+
Checking    |                908|
Savings     |                895|
```