### PR TITLE
Missing configuration for user mock url in k8s-beta profile

### DIFF
--- a/src/main/resources/application-k8s-beta.yml
+++ b/src/main/resources/application-k8s-beta.yml
@@ -18,6 +18,7 @@ bb-fuel:
     legalentity: http://legalentity.${environment.name}.${environment.domain}
     transactions: http://transactions.${environment.name}.${environment.domain}/integration-api
     user: http://user-manager.${environment.name}.${environment.domain}/integration-api
+    usermock: http://usermock-${environment.name}.${environment.domain}/service-api
     accountStatement: http://accountstatementsintegration.${environment.name}.${environment.domain}/service-api
     pockets: http://edge.${environment.name}.${environment.domain}/api/pocket-tailor/client-api
     pocketsArrangements: http://arrangementoutboundoriginationmock.${environment.name}.${environment.domain}/service-api


### PR DESCRIPTION
bb-fuel fails to start when trying to ingest data with `k8s-beta` profile

https://jenkins.backbase.eu/blue/organizations/jenkins/QA%20Guild%2FCT%2FBB-Fuel/detail/BB-Fuel/25183/pipeline/