### PR TITLE
PRSUM-10419-support product kind Investment Portfolio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <common-types.version>1.0.5</common-types.version>
 
         <!-- Products Specs Versions -->
-        <arrangement-client-api.version>2.11.1</arrangement-client-api.version>
+        <arrangement-client-api.version>2.12.5</arrangement-client-api.version>
         <arrangement-integration-outbound-link-account-api.version>2.1.1</arrangement-integration-outbound-link-account-api.version>
         <arrangement-integration-outbound-origination-api.version>1.0.3</arrangement-integration-outbound-origination-api.version>
         <arrangement-integration-inbound-api.version>2.7.2</arrangement-integration-inbound-api.version>

--- a/src/main/resources/data/products.json
+++ b/src/main/resources/data/products.json
@@ -47,5 +47,12 @@
     "productKindName": "Investment Account",
     "productTypeId": "7777777",
     "productTypeName": "Investment Account"
+  },
+  {
+    "id": "102",
+    "productKindId": "kind102",
+    "productKindName": "Investment Portfolio",
+    "productTypeId": "102102102",
+    "productTypeName": "Investment Portfolio"
   }
 ]

--- a/src/main/resources/data/retail/product-group-seed.json
+++ b/src/main/resources/data/retail/product-group-seed.json
@@ -9,10 +9,11 @@
       "Current Account",
       "Joint Account",
       "Savings Account",
-      "Credit Card"
+      "Credit Card",
+      "Investment Portfolio"
     ],
     "productIds": [
-      "1","2", "4", "7"
+      "1","2", "4", "7", "102"
     ],
     "numberOfArrangements": {
       "min": 8,


### PR DESCRIPTION
Added a new product kind "Investment Portfolio", it can be ingested in the beck environments with the static kind profile.

![image](https://github.com/user-attachments/assets/c1e6dbab-eb8b-40e0-a1b4-6077f0777558)

![image](https://github.com/user-attachments/assets/e4aa1802-7051-4c1a-b233-72895396e2a4)

![image](https://github.com/user-attachments/assets/36512653-6d83-49f0-8a07-3d9b5c273c6b)
